### PR TITLE
Add minimist lib to chrome_app.

### DIFF
--- a/src/app/build/tasks/chrome_app_manifest.js
+++ b/src/app/build/tasks/chrome_app_manifest.js
@@ -42,6 +42,7 @@ var makeManifest = function(version, mode) {
           "js/axiom_npm_deps.amd.js",
           "js/axiom.amd.js",
           "js/shell.amd.js",
+          "js/shell_npm_deps.amd.js",
           "js/chrome_app_background.js"
         ]
       }

--- a/src/app/gruntfile.js
+++ b/src/app/gruntfile.js
@@ -108,7 +108,7 @@ module.exports = function(grunt) {
           { expand: true,
             cwd: 'out/concat/lib',
             src: [pkg.name + '_npm_deps.amd.js'],
-            dest: 'out/web_app/js/'
+            dest: 'out/chrome_app/js/'
           }
         ]
       },


### PR DESCRIPTION
- Fixes a bug in gruntfile where minimist lib was getting copied incorrectly
- Adds minimist lib to chrome_app build.

The chrome app is still broken with some polymer issue investigating it.

@rginda 
