### PR TITLE
Closure annotations into shell app

### DIFF
--- a/src/addon/editor/lib/axiom_editor/editor.js
+++ b/src/addon/editor/lib/axiom_editor/editor.js
@@ -6,7 +6,14 @@ import AxiomError from 'axiom/core/error';
 
 import environment from 'shell/environment';
 
-export var EditorView = function(filePath) {
+/**
+ * @constructor
+ * An implementation of ace for editing files in an Axiom view.
+ *
+ * @param {string} filePath
+ */
+var EditorView = function(filePath) {
+
   EditorView.sequence++;
   this.id = 'editor-' + EditorView.sequence;
   this.filePath = filePath;
@@ -56,6 +63,7 @@ export var EditorView = function(filePath) {
     }.bind(this));
 };
 
+export {EditorView};
 export default EditorView;
 
 EditorView.sequence = 0;

--- a/src/addon/editor/package.json
+++ b/src/addon/editor/package.json
@@ -11,6 +11,7 @@
   "readmeFilename": "README.md",
   "devDependencies": {
     "grunt": "^0.4.5",
+    "grunt-closure-compiler": "0.0.21",
     "grunt-bower-task": "^0.4.0",
     "grunt-contrib-clean": "~0.5.0",
     "grunt-contrib-concat": "~0.5.0",

--- a/src/app/lib/shell/commands.js
+++ b/src/app/lib/shell/commands.js
@@ -17,11 +17,16 @@ import AxiomError from 'axiom/core/error';
 import environment from 'shell/environment';
 import TerminalView from 'shell/views/terminal';
 
-export var ShellCommands = function(moduleManager) {
+/**
+ * @constructor @extends {BaseBinding};
+ * @param {ModuleManager} moduleManager
+ */
+var ShellCommands = function(moduleManager) {
   this.moduleManager = moduleManager;
   this.extensionBinding = null;
 };
 
+export {ShellCommands};
 export default ShellCommands;
 
 ShellCommands.prototype.bind = function(extensionBinding) {

--- a/src/app/lib/shell/exe/hterm.js
+++ b/src/app/lib/shell/exe/hterm.js
@@ -17,8 +17,11 @@ import TerminalView from 'shell/views/terminal';
 /**
  * Simple callback for a JsExecutable which echos the argument list to stdout
  * and exits.
+ *
+ * @this {JsExecutable}
+ * @param {ExecuteContext} cx
  */
-export var main = function(cx) {
+var main = function(cx) {
   cx.ready();
   var tv = new TerminalView(this.moduleManager);
   var command = cx.arg['command'] || '/addon/shell/exe/wash';
@@ -31,6 +34,7 @@ export var main = function(cx) {
   return Promise.resolve(null);
 };
 
+export {main};
 export default main;
 
 /**

--- a/src/app/lib/shell/exe/readline.js
+++ b/src/app/lib/shell/exe/readline.js
@@ -17,9 +17,12 @@ import AxiomError from 'axiom/core/error';
 import Termcap from 'shell/util/termcap';
 
 /**
+ * @constructor
  * A partial clone of GNU readline.
+ *
+ * @param {ExecuteContext} executeContext
  */
-export var Readline = function(executeContext) {
+var Readline = function(executeContext) {
   this.executeContext = executeContext;
   this.executeContext.onStdIn.addListener(this.onStdIn_, this);
 
@@ -55,6 +58,8 @@ export var Readline = function(executeContext) {
   this.bindings = {};
   this.addKeyBindings(Readline.defaultBindings);
 };
+
+export {Readline};
 
 export var main = function(executeContext) {
   var inputHistory = executeContext.arg.inputHistory;
@@ -341,6 +346,9 @@ Readline.prototype.onStdIn_ = function(value) {
 
 Readline.prototype.commands = {};
 
+/**
+ * @this {Readline}
+ */
 Readline.prototype.commands['clear-home'] = function(string) {
   this.print('%clear-terminal()%set-row-column(row, column)',
              {row: 0, column: 0});
@@ -349,6 +357,9 @@ Readline.prototype.commands['clear-home'] = function(string) {
   this.print('%get-row-column()');
 };
 
+/**
+ * @this {Readline}
+ */
 Readline.prototype.commands['redraw-line'] = function(string) {
   if (!this.cursorHome_) {
     console.warn('readline: Home cursor position unknown, won\'t redraw.');
@@ -420,10 +431,16 @@ Readline.prototype.commands['redraw-line'] = function(string) {
   this.dispatch('reposition-cursor');
 };
 
+/**
+ * @this {Readline}
+ */
 Readline.prototype.commands['abort-line'] = function() {
   this.resolve_(null);
 };
 
+/**
+ * @this {Readline}
+ */
 Readline.prototype.commands['reposition-cursor'] = function(string) {
   // Count the number or rows it took to render the current line at the
   // current terminal width.
@@ -438,6 +455,9 @@ Readline.prototype.commands['reposition-cursor'] = function(string) {
              });
 };
 
+/**
+ * @this {Readline}
+ */
 Readline.prototype.commands['self-insert'] = function(string) {
   if (this.linePosition == this.line.length) {
     this.line += string;
@@ -453,6 +473,9 @@ Readline.prototype.commands['self-insert'] = function(string) {
   this.dispatch('redraw-line');
 };
 
+/**
+ * @this {Readline}
+ */
 Readline.prototype.commands['accept-line'] = function() {
   this.historyIndex_ = 0;
   if (this.line && this.line != this.history_[1])
@@ -461,6 +484,9 @@ Readline.prototype.commands['accept-line'] = function() {
   this.resolve_(this.line);
 };
 
+/**
+ * @this {Readline}
+ */
 Readline.prototype.commands['beginning-of-history'] = function() {
   this.historyIndex_ = this.history_.length - 1;
   this.line = this.history_[this.historyIndex_];
@@ -469,6 +495,9 @@ Readline.prototype.commands['beginning-of-history'] = function() {
   this.dispatch('redraw-line');
 };
 
+/**
+ * @this {Readline}
+ */
 Readline.prototype.commands['end-of-history'] = function() {
   this.historyIndex_ = this.history_.length - 1;
   this.line = this.history_[this.historyIndex_];
@@ -477,6 +506,9 @@ Readline.prototype.commands['end-of-history'] = function() {
   this.dispatch('redraw-line');
 };
 
+/**
+ * @this {Readline}
+ */
 Readline.prototype.commands['previous-history'] = function() {
   if (this.historyIndex_ == this.history_.length - 1) {
     this.print('%bell()');
@@ -490,6 +522,9 @@ Readline.prototype.commands['previous-history'] = function() {
   this.dispatch('redraw-line');
 };
 
+/**
+ * @this {Readline}
+ */
 Readline.prototype.commands['next-history'] = function() {
   if (this.historyIndex_ === 0) {
     this.print('%bell()');
@@ -503,6 +538,9 @@ Readline.prototype.commands['next-history'] = function() {
   this.dispatch('redraw-line');
 };
 
+/**
+ * @this {Readline}
+ */
 Readline.prototype.commands['kill-word'] = function() {
   var start = this.linePosition;
   var length =  this.getWordEnd() - start;
@@ -511,6 +549,9 @@ Readline.prototype.commands['kill-word'] = function() {
   this.dispatch('redraw-line');
 };
 
+/**
+ * @this {Readline}
+ */
 Readline.prototype.commands['backward-kill-word'] = function() {
   var start = this.getWordStart();
   var length = this.linePosition - start;
@@ -520,12 +561,18 @@ Readline.prototype.commands['backward-kill-word'] = function() {
   this.dispatch('redraw-line');
 };
 
+/**
+ * @this {Readline}
+ */
 Readline.prototype.commands['kill-line'] = function() {
   this.killSlice(this.linePosition, -1);
 
   this.dispatch('redraw-line');
 };
 
+/**
+ * @this {Readline}
+ */
 Readline.prototype.commands['yank'] = function() {
   var text = this.killRing_[0];
   this.line = (this.line.substr(0, this.linePosition) +
@@ -536,6 +583,9 @@ Readline.prototype.commands['yank'] = function() {
   this.dispatch('redraw-line');
 };
 
+/**
+ * @this {Readline}
+ */
 Readline.prototype.commands['yank-last-arg'] = function() {
   if (this.history_.length < 2)
     return;
@@ -546,6 +596,9 @@ Readline.prototype.commands['yank-last-arg'] = function() {
     this.dispatch('self-insert', last.substr(i));
 };
 
+/**
+ * @this {Readline}
+ */
 Readline.prototype.commands['delete-char-or-eof'] = function() {
   if (!this.line.length) {
     this.dispatch('abort-line');
@@ -554,6 +607,9 @@ Readline.prototype.commands['delete-char-or-eof'] = function() {
   }
 };
 
+/**
+ * @this {Readline}
+ */
 Readline.prototype.commands['delete-char'] = function() {
   if (this.linePosition < this.line.length) {
     this.line = (this.line.substr(0, this.linePosition) +
@@ -564,6 +620,9 @@ Readline.prototype.commands['delete-char'] = function() {
   }
 };
 
+/**
+ * @this {Readline}
+ */
 Readline.prototype.commands['backward-delete-char'] = function() {
   if (this.linePosition > 0) {
     this.linePosition -= 1;
@@ -575,6 +634,9 @@ Readline.prototype.commands['backward-delete-char'] = function() {
   }
 };
 
+/**
+ * @this {Readline}
+ */
 Readline.prototype.commands['backward-char'] = function() {
   if (this.linePosition > 0) {
     this.linePosition -= 1;
@@ -584,6 +646,9 @@ Readline.prototype.commands['backward-char'] = function() {
   }
 };
 
+/**
+ * @this {Readline}
+ */
 Readline.prototype.commands['forward-char'] = function() {
   if (this.linePosition < this.line.length) {
     this.linePosition += 1;
@@ -593,17 +658,26 @@ Readline.prototype.commands['forward-char'] = function() {
   }
 };
 
+/**
+ * @this {Readline}
+ */
 Readline.prototype.commands['backward-word'] = function() {
   this.linePosition = this.getWordStart();
   this.dispatch('reposition-cursor');
 };
 
 
+/**
+ * @this {Readline}
+ */
 Readline.prototype.commands['forward-word'] = function() {
   this.linePosition = this.getWordEnd();
   this.dispatch('reposition-cursor');
 };
 
+/**
+ * @this {Readline}
+ */
 Readline.prototype.commands['beginning-of-line'] = function() {
   if (this.linePosition === 0) {
     this.print('%bell()');
@@ -614,6 +688,9 @@ Readline.prototype.commands['beginning-of-line'] = function() {
   this.dispatch('reposition-cursor');
 };
 
+/**
+ * @this {Readline}
+ */
 Readline.prototype.commands['end-of-line'] = function() {
   if (this.linePosition == this.line.length) {
     this.print('%bell()');
@@ -624,6 +701,9 @@ Readline.prototype.commands['end-of-line'] = function() {
   this.dispatch('reposition-cursor');
 };
 
+/**
+ * @this {Readline}
+ */
 Readline.prototype.commands['undo'] = function() {
   if ((this.nextUndoIndex_ == this.undo_.length)) {
     this.print('%bell()');

--- a/src/app/lib/shell/exe/wash.js
+++ b/src/app/lib/shell/exe/wash.js
@@ -25,9 +25,13 @@ import WashBuiltins from 'shell/exe/wash_builtins';
 import environment from 'shell/environment';
 
 /**
+ * @constructor
+ *
  * The shell read-eval-print loop.
+ * 
+ * @param {ExecuteContext} executeContext
  */
-export var Shell = function(executeContext) {
+var Shell = function(executeContext) {
   this.executeContext = executeContext;
   executeContext.onSignal.addListener(this.onSignal_.bind(this));
 
@@ -445,3 +449,5 @@ Shell.prototype.onSignal_ = function(name) {
   if (name == 'interrupt')
     this.readEvalPrintLoop();
 };
+
+export {Shell};

--- a/src/app/lib/shell/exe/wash_builtins.js
+++ b/src/app/lib/shell/exe/wash_builtins.js
@@ -17,6 +17,8 @@ import JsEntry from 'axiom/fs/js_entry';
 import Path from 'axiom/fs/path';
 
 /**
+ * @constructor
+ *
  * Shell builtins with special access to the current shell instance.
  *
  * These are not installed in the local JSFS filesystem because builtins
@@ -26,7 +28,7 @@ import Path from 'axiom/fs/path';
  * @param {Shell} shellInstance The instance of the shell these builtins should
  *   act on.
  */
-export var WashBuiltins = function(shellInstance) {
+var WashBuiltins = function(shellInstance) {
   this.callbacks = {
     'pwd()': function(executeContext) {
       executeContext.ready();
@@ -103,4 +105,5 @@ export var WashBuiltins = function(shellInstance) {
   };  // this.callbacks = {
 };
 
+export {WashBuiltins};
 export default WashBuiltins;

--- a/src/app/lib/shell/file_system.js
+++ b/src/app/lib/shell/file_system.js
@@ -29,12 +29,18 @@ import readlineMain from 'shell/exe/readline';
 import rmMain from 'shell/exe/rm';
 import washMain from 'shell/exe/wash';
 
-export var ShellFS = function(moduleManager) {
+/**
+ * @constructor
+ * 
+ * @param {ModuleManager} moduleManager
+ */
+var ShellFS = function(moduleManager) {
   this.moduleManager = moduleManager;
   this.fileSystemExtensionBinding = null;
   this.jsfs = null;
 };
 
+export {ShellFS};
 export default ShellFS;
 
 ShellFS.prototype.bind = function(fileSystemExtensionBinding) {

--- a/src/app/lib/shell/util/string.js
+++ b/src/app/lib/shell/util/string.js
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-export var string = {};
+var string = {};
 export default string;
 
 /**
@@ -53,6 +53,7 @@ string.zpad = function(number, length) {
  *
  * @param {integer} length The desired amount of whitespace.
  * @param {string} A string of spaces of the requested length.
+ * @this {string}
  */
 string.getWhitespace = function(length) {
   if (length === 0)
@@ -68,3 +69,5 @@ string.getWhitespace = function(length) {
 
   return f.whitespace.substr(0, length);
 };
+
+export {string};

--- a/src/app/lib/shell/util/termcap.js
+++ b/src/app/lib/shell/util/termcap.js
@@ -13,6 +13,8 @@
 // limitations under the License.
 
 /**
+ * @constructor
+ *
  * Class used to convert lib.replaceVars-like strings into actual terminal
  * escape.
  *

--- a/src/app/lib/shell/views/terminal.js
+++ b/src/app/lib/shell/views/terminal.js
@@ -18,7 +18,10 @@ import environment from 'shell/environment';
 
 import hterm from 'hterm/public';
 
-export var TerminalView = function() {
+/**
+ * @constructor
+ */
+var TerminalView = function() {
   TerminalView.sequence++;
   this.id = 'terminal-' + TerminalView.sequence;
 
@@ -90,6 +93,7 @@ export var TerminalView = function() {
     }.bind(this));
 };
 
+export {TerminalView};
 export default TerminalView;
 
 TerminalView.sequence = 0;

--- a/src/app/lib/shell/windows.js
+++ b/src/app/lib/shell/windows.js
@@ -17,11 +17,17 @@ import AxiomError from 'axiom/core/error';
 // For jshint...
 /* global chrome */
 
-export var ShellWindows = function(moduleManager) {
+/**
+ * @constructor
+ * 
+ * @param {ModuleManager} moduleManager
+ */
+var ShellWindows = function(moduleManager) {
   this.moduleManager_ = moduleManager;
   this.extensionBinding_ = null;
 };
 
+export {ShellWindows};
 export default ShellWindows;
 
 ShellWindows.prototype.bind = function(extensionBinding) {


### PR DESCRIPTION
Fixes all but hterm / minimist ("namespace never provided") closure errors / warnings.
- Created `@constructor` annotations
- moved exports to their own statements
- added `@this` specificity
- added some `@params`
- and defined main's scope (by declaring `@this`'s class)

Please review @rginda 
