### PR TITLE
Use updated version of es6-module-transpiler.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,6 @@
 *~
+
+# VS artifacts
+*.suo
+*.sln
+project.vs-chromium-project

--- a/src/core/build/tasks/es6_module_transpiler.js
+++ b/src/core/build/tasks/es6_module_transpiler.js
@@ -1,0 +1,89 @@
+// Copyright 2015 Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/*
+ * Update grunt-es6-module-transpiler to support e6-module-transpiler v0.5+
+ * and amd formatter.
+ */
+
+'use strict';
+
+module.exports = function(grunt) {
+  var path = require('path');
+
+  function transpile(file, options) {
+    var src = file.src;
+    var ext = path.extname(src);
+
+    // module name = 'cwd' option + base file name
+    var moduleName = path
+        .join(path.dirname(src), path.basename(src, ext))
+        .replace(/[\\]/g, '/');  // Deal with Windows separators.
+    if (file.orig.cwd) {
+      moduleName = moduleName.slice(file.orig.cwd.length);
+    }
+
+    var transpiler = require('es6-module-transpiler');
+
+    // Figure out formatter to use according to options. "AMD" requires an
+    // additional module.
+    var formatter;
+    switch(options.type){
+    case 'cjs':
+      formatter = transpiler.formatters.commonjs;
+      break;
+    case 'amd':
+      var AMDFormatter = require('es6-module-transpiler-amd-formatter');
+      formatter = new AMDFormatter();
+      break;
+    default:
+      throw new Error("unknown transpile destination type: " + options.type);
+    }
+
+    // Create a container with the file resolvers and formatter, find the module
+    // name and write it to disk.
+    var container = new transpiler.Container({
+      resolvers: [new transpiler.FileResolver(options.fileResolver)],
+      formatter: formatter
+    });
+    container.getModule(moduleName);
+    container.write(file.dest);
+  }
+
+  grunt.registerMultiTask("es6_transpile", function(){
+    var opts = {};
+    opts.fileResolver = this.data.fileResolver;
+    opts.type = this.data.type;
+    opts.moduleName = this.data.moduleName;
+
+    // Transpile one file at a time.
+    this.files.forEach(function(file){
+      file.src.filter(function(path){
+        if(!grunt.file.exists(path)){
+          grunt.log.warn('Source file "' + path + '" not found.');
+          return false;
+        } else {
+          return true;
+        }
+      }).forEach(function(path){
+        try {
+          transpile({src:path, dest:file.dest, orig:file.orig}, opts);
+        } catch (e) {
+          grunt.log.error(e);
+          grunt.fail.warn('Error compiling ' + path);
+        }
+      });
+    });
+  });
+};

--- a/src/core/gruntfile.js
+++ b/src/core/gruntfile.js
@@ -113,9 +113,15 @@ module.exports = function(grunt) {
     // Convert our ES6 import/export keywords into plain js.  We generate an
     // AMD version for use in the browser, and a CommonJS version for use in
     // node.js.
-    transpile: {
+    es6_transpile: {
       amd: {
         type: "amd",
+        // Defines the "root" directories used by the transpiler to resolve
+        // import to files.
+        fileResolver: [
+          'lib/',
+          'node_modules/semver/'
+        ],
         files: [{
           expand: true,
           cwd: 'lib/',
@@ -125,6 +131,12 @@ module.exports = function(grunt) {
       },
       cjs: {
         type: "cjs",
+        // Defines the "root" directories used by the transpiler to resolve
+        // import to files.
+        fileResolver: [
+          'lib/',
+          'node_modules/semver/'
+        ],
         files: [{
           expand: true,
           cwd: 'lib/',
@@ -220,7 +232,7 @@ module.exports = function(grunt) {
   grunt.registerTask('build_polymer', ['bower:install', 'sync:bower_components',
                      'clean:polymer', 'vulcanize', 'copy:polymer_out',
                      'clean:polymer_lib']);
-  grunt.registerTask('build', ['jshint', 'clean:transpile', 'transpile',
+  grunt.registerTask('build', ['jshint', 'clean:transpile', 'es6_transpile',
                                'npm_adapt', 'build_polymer', 'concat',
                                'uglify']);
   grunt.registerTask('dist', ['build', 'copy:dist']);

--- a/src/core/lib/axiom/fs/js_file_system.js
+++ b/src/core/lib/axiom/fs/js_file_system.js
@@ -28,9 +28,6 @@ import JsResolveResult from 'axiom/fs/js_resolve_result';
 /** @typedef ExecuteContext$$module$axiom$bindings$fs$execute_context */
 var ExecuteContext;
 
-/** @typedef FileSystem$$module$axiom$bindings$fs$file_system */
-var FileSystem;
-
 /** @typedef OpenContext$$module$axiom$bindings$fs$open_context */
 var OpenContext;
 

--- a/src/core/package.json
+++ b/src/core/package.json
@@ -20,7 +20,8 @@
     "grunt-contrib-jshint": "~0.10.0",
     "grunt-contrib-uglify": "~0.5.0",
     "grunt-contrib-watch": "^0.6.1",
-    "grunt-es6-module-transpiler": "^0.6.0",
+    "es6-module-transpiler": "~0.9.6",
+    "es6-module-transpiler-amd-formatter": "~0.2.4",
     "grunt-sync": "~0.2.2",
     "grunt-vulcanize": "^0.5.0",
     "matchdep": "~0.3.0"


### PR DESCRIPTION
- This applies to "core" only for now.
- The AMD code generation is compatible with the old one used for "app" and "addon"

@rginda 
