### PR TITLE
Make "grunt check" error free.

### DIFF
--- a/lib/axiom/fs/js/file_system.test.js
+++ b/lib/axiom/fs/js/file_system.test.js
@@ -27,7 +27,7 @@ describe('JsFileSystem', function () {
   describe('when empty', function () {
     it('should have a root folder', function(done) {
       var fs = new JsFileSystem();
-      fs.stat().then(function (rv) {
+      fs.stat('').then(function (rv) {
           expect(rv).toBeDefined();
           expect(rv.mode).toBe(8);
           expect(rv.count).toBe(0);

--- a/third_party/closure-compiler/contrib/externs/jasmine.js
+++ b/third_party/closure-compiler/contrib/externs/jasmine.js
@@ -377,11 +377,11 @@ jasmine.Env.prototype.beforeEach = function(handler) {};
 jasmine.getEnv = function() {};
 
 
-/** @param {function(this:jasmine.Spec)} handler */
+/** @param {function(this:jasmine.Spec, function(): void)} handler */
 function afterEach(handler) {}
 
 
-/** @param {function(this:jasmine.Spec)} handler */
+/** @param {function(this:jasmine.Spec, function(): void)} handler */
 function beforeEach(handler) {}
 
 
@@ -408,14 +408,14 @@ function inject(var_args) {}
 
 /**
  * @param {string} description
- * @param {function(this:jasmine.Spec)} handler
+ * @param {function(this:jasmine.Spec, function(): void)} handler
  */
 function it(description, handler) {}
 
 
 /**
  * @param {string} description
- * @param {function(this:jasmine.Spec)} handler
+ * @param {function(this:jasmine.Spec, function(): void)} handler
  */
 function iit(description, handler) {}
 


### PR DESCRIPTION
- Fix jasmine extern declarations to include the Jasmine 2.0 "done" parameter for handlers.

@rginda 
