### PR TITLE
Follow-up closure annotation & minimist restore

### DIFF
--- a/src/app/lib/shell/exe/wash.js
+++ b/src/app/lib/shell/exe/wash.js
@@ -19,7 +19,7 @@ import JsEntry from 'axiom/fs/js_entry';
 import Path from 'axiom/fs/path';
 import domfsUtil from 'axiom/fs/domfs_util';
 
-// import minimist from 'minimist';
+import minimist from 'minimist';
 import Termcap from 'shell/util/termcap';
 import WashBuiltins from 'shell/exe/wash_builtins';
 import environment from 'shell/environment';
@@ -386,7 +386,7 @@ Shell.prototype.parseArgv = function(argSigil, argv) {
       return argv ? argv.split(/\s+/g) : [];
 
     // TODO(rginda, ericarnold): Figure out how to solve minimist as an AMD
-    // if (argSigil == '%') return minimist(argv.split(/\s+/g), {});
+    if (argSigil == '%') return minimist(argv.split(/\s+/g), {});
   }
 };
 

--- a/src/core/lib/axiom/bindings/fs/file_system.js
+++ b/src/core/lib/axiom/bindings/fs/file_system.js
@@ -114,7 +114,7 @@ FileSystem.prototype.move = function (pathSpecFrom, pathSpecTo) {};
  * Bindable method.
  *
  * @param {string} pathSpec
- * @return {Promise<StatResult>}
+ * @return {!Promise<!StatResult>}
  */
 FileSystem.prototype.stat = function(pathSpec) {};
 


### PR DESCRIPTION
Fixes closure issue and fixes axiom param parsing (minimist), which breaks closure again for now:
- Restored minimist (will break closure build)
- Fixed Promise type-mismatch

@rginda 
