### PR TITLE
Replacing pathSpec with absolute path (path.spec) in cd

### DIFF
--- a/lib/wash/exe/wash.js
+++ b/lib/wash/exe/wash.js
@@ -123,6 +123,7 @@ Wash.Builtins = function(wash) {
       /** @type {string} */
       var pathSpec = wash.absPath(cx.arg || cx.getEnv('$HOME', '/'));
       var path = new Path(pathSpec);
+      pathSpec = path.spec;
 
       wash.fileSystem.stat(path).then(
         function(/** StatResult */ statResult) {


### PR DESCRIPTION
Replacing `pathSpec` with `new Path().spec` to get absolute path during `cd`.

Fixes #50

@rginda, PTAL
