### PR TITLE
Properly bind this in ExecuteContext functions.

### DIFF
--- a/lib/axiom/fs/base/execute_context.js
+++ b/lib/axiom/fs/base/execute_context.js
@@ -357,7 +357,7 @@ ExecuteContext.prototype.createExecuteContext = function(path, arg) {
     function(cx) {
       cx.dependsOn(this);
       return cx;
-    });
+    }.bind(this));
 };
 
 /**
@@ -373,7 +373,7 @@ ExecuteContext.prototype.createOpenContext = function(path, mode) {
     function(cx) {
       cx.dependsOn(this);
       return cx;
-    });
+    }.bind(this));
 };
 
 /**


### PR DESCRIPTION
create{Execute,Open}Context were not binding this, so would always fail.
