### PR TITLE
Modify the test-watch tasks to build a standalone jasmine harness

### DIFF
--- a/build/tasks/make_html_index.js
+++ b/build/tasks/make_html_index.js
@@ -17,7 +17,7 @@
 module.exports = function(grunt) {
   grunt.registerMultiTask('make_html_index', function() {
 
-    mainsrc = '<!DOCTYPE html>\n';
+    var mainsrc = '<!DOCTYPE html>\n';
     mainsrc += '<html>\n';
     mainsrc += '<head>\n';
     mainsrc += '<title>' + this.data.title + '</title>\n';
@@ -25,7 +25,18 @@ module.exports = function(grunt) {
     if (this.data.cssrefs) {
       var cssrefs = grunt.file.expand(this.data, this.data.cssrefs);
       cssrefs.forEach(function(cssref) {
-        mainsrc += '  <link rel="stylesheet" type="text/css" href="' + cssref + '">\n';
+        mainsrc += '  <link rel="stylesheet" type="text/css" href="' + cssref +
+            '">\n';
+      }.bind(this));
+    }
+
+    if (this.data.inlines) {
+      this.data.inlines.forEach(function(inline) {
+        if (/\.js$/.test(inline)) {
+          mainsrc += '<script>' + grunt.file.read(inline) + '</script>\n';
+        } else if (/\.css$/.test(inline)) {
+          mainsrc += '<style>' + grunt.file.read(inline) + '</style>\n';
+        }
       }.bind(this));
     }
 

--- a/gruntfile.js
+++ b/gruntfile.js
@@ -230,6 +230,27 @@ module.exports = function(grunt) {
         cssrefs: [
           'css/**/*.css'
         ]
+      },
+
+      test_harness: {
+        dest: 'tmp/test_harness.html',
+        title: 'test',
+        cwd: 'tmp/',
+        inlines: [
+          'node_modules/jasmine-core/lib/jasmine-core/jasmine.css',
+          'node_modules/jasmine-core/lib/jasmine-core/jasmine.js',
+          'node_modules/jasmine-core/lib/jasmine-core/jasmine-html.js',
+          'node_modules/jasmine-core/lib/jasmine-core/boot.js',
+          'loader/axiom_amd.js'
+        ],
+        scriptrefs: [
+          'amd/lib/axiom/**/*.js',
+          'amd/lib/wash/**/*.js',
+          'test/test_main.js'
+        ],
+        cssrefs: [
+          'css/**/*.css'
+        ]
       }
     },
 
@@ -241,12 +262,14 @@ module.exports = function(grunt) {
         files: ['lib/**/*.js'],
         tasks: ['check']
       },
-      test: {
+      test_harness: {
         options: {
           atBegin: true
         },
         files: ['lib/**/*.js', 'test/**/*.js'],
-        tasks: ['transpile', 'make_main_module:test', 'karma:once']
+        tasks: ['transpile',
+                'make_main_module:test',
+                'make_html_index:test_harness']
       },
       samples: {
         options: {
@@ -255,12 +278,15 @@ module.exports = function(grunt) {
         files: ['lib/**/*.js', 'samples/**/*.js'],
         tasks: ['check', 'samples']
       },
-      check_test: {
+      check_test_harness: {
         options: {
           atBegin: true
         },
         files: ['lib/**/*.js', 'test/**/*.js'],
-        tasks: ['check', 'transpile', 'make_main_module:test', 'karma:once']
+        tasks: ['check',
+                'transpile',
+                'make_main_module:test',
+                'make_html_index:test_harness']
       }
     },
 
@@ -366,11 +392,14 @@ module.exports = function(grunt) {
   grunt.registerTask('test', ['transpile',
                               'make_main_module:test',
                               'karma:once']);
-  grunt.registerTask('test-watch', ['clean',
-                                    'watch:test']);
+  grunt.registerTask('test-watch',
+                     ['clean',
+                      'watch:test_harness']);
 
   // Static check, transpile, test, repeat on changes.
-  grunt.registerTask('check-test-watch', ['clean', 'watch:check_test']);
+  grunt.registerTask('check-test-watch',
+                     ['clean',
+                      'watch:check_test_harness']);
 
   // Build, then run wash from node.js
   grunt.registerTask('wash', ['clean',


### PR DESCRIPTION
This allows you to run jasmine in a standard chrome profile and debug
the tests like any other page.

To use start a web server from the project root, like:
  cd axiom
  http-server -c -1

Then in another terminal window run
  grunt check-test-watch
  -- or --
  grunt test-watch

Depending on whether or not you want to run closure.

In your web browser, load localhost:8080/tmp/test_harness.html and
do what comes naturally.

@rpaquay PTAL
