### PR TITLE
Add ttyin/ttyout as stdio streams.

### DIFF
--- a/lib/axiom/fs/base/execute_context.js
+++ b/lib/axiom/fs/base/execute_context.js
@@ -101,6 +101,10 @@ export var ExecuteContext = function(fileSystem, stdio, path, args) {
   this.stdout = stdio.stdout;
   /** @type {!WritableStream} */
   this.stderr = stdio.stderr;
+  /** @type {!ReadableStream} */
+  this.ttyin = stdio.ttyin;
+  /** @type {!WritableStream} */
+  this.ttyout = stdio.ttyout;
   /** @type {!AxiomEvent} */
   this.onTTYChange = new AxiomEvent();
   /** @type {!AxiomEvent} */
@@ -201,6 +205,8 @@ ExecuteContext.prototype.setStdio = function(stdio) {
   this.stdin = stdio.stdin;
   this.stdout = stdio.stdout;
   this.stderr = stdio.stderr;
+  this.ttyin = stdio.ttyin;
+  this.ttyout = stdio.ttyout;
 };
 
 /**

--- a/lib/axiom/fs/nested_stdio.js
+++ b/lib/axiom/fs/nested_stdio.js
@@ -21,14 +21,16 @@ import ReadableStreamForwarder from 'axiom/fs/stream/readable_stream_forwarder';
  * @param {!Stdio} parentStdio
  */
 export var NestedStdio = function(parentStdio) {
-  // Note: we wrap stin so that any "onData" event handler added is scoped
-  // to the nested stdio lifetime.
+  // Note: we wrap stdin and ttyin so that any "onData" event handler added is
+  // scoped to the nested stdio lifetime.
   var stdin = new ReadableStreamForwarder(parentStdio.stdin);
-  // Note: stdout and stderr don't need to be wrapped as they don't expose
-  // events.
+  var ttyin = new ReadableStreamForwarder(parentStdio.ttyin);
+  // Note: stdout, stderr and ttyout don't need to be wrapped as they don't
+  // expose events.
   var stdout = parentStdio.stdout;
   var stderr = parentStdio.stderr;
-  Stdio.call(this, stdin, stdout, stderr);
+  var ttyout = parentStdio.ttyout;
+  Stdio.call(this, stdin, stdout, stderr, ttyin, ttyout);
 
   /** @const @type {!Stdio} */
   this.parentStdio = parentStdio;

--- a/lib/axiom/fs/stdio.js
+++ b/lib/axiom/fs/stdio.js
@@ -23,14 +23,20 @@ var WritableStream;
  * @param {!ReadableStream} stdin
  * @param {!WritableStream} stdout
  * @param {!WritableStream} stderr
+ * @param {!ReadableStream} ttyin
+ * @param {!WritableStream} ttyout
  */
-export var Stdio = function(stdin, stdout, stderr) {
+export var Stdio = function(stdin, stdout, stderr, ttyin, ttyout) {
   /** @const @type {!ReadableStream} */
   this.stdin = stdin;
   /** @const @type {!WritableStream} */
   this.stdout = stdout;
   /** @const @type {!WritableStream} */
   this.stderr = stderr;
+  /** @const @type {!ReadableStream} */
+  this.ttyin = ttyin;
+  /** @const @type {!WritableStream} */
+  this.ttyout = ttyout;
 };
 
 export default Stdio;

--- a/lib/axiom/fs/stdio_source.js
+++ b/lib/axiom/fs/stdio_source.js
@@ -23,7 +23,7 @@ var ReadableStream;
 var WritableStream;
 
 /**
- * @constructor 
+ * @constructor
  */
 export var StdioSource = function() {
   /** @const @private @type {!MemoryStreamBuffer} */
@@ -32,6 +32,10 @@ export var StdioSource = function() {
   this.stdoutBuffer_ = new MemoryStreamBuffer();
   /** @const @private @type {!MemoryStreamBuffer} */
   this.stderrBuffer_ = new MemoryStreamBuffer();
+  /** @const @private @type {!MemoryStreamBuffer} */
+  this.ttyinBuffer_ = new MemoryStreamBuffer();
+  /** @const @private @type {!MemoryStreamBuffer} */
+  this.ttyoutBuffer_ = new MemoryStreamBuffer();
 
   /** @const @type {!WritableStream} */
   this.stdin = this.stdinBuffer_.writableStream;
@@ -39,12 +43,18 @@ export var StdioSource = function() {
   this.stdout = this.stdoutBuffer_.readableStream;
   /** @const @type {!ReadableStream} */
   this.stderr = this.stderrBuffer_.readableStream;
+  /** @const @type {!WritableStream} */
+  this.ttyin = this.ttyinBuffer_.writableStream;
+  /** @const @type {!ReadableStream} */
+  this.ttyout = this.ttyoutBuffer_.readableStream;
 
   /** @const @type {!Stdio} */
   this.stdio = new Stdio(
-    this.stdinBuffer_.readableStream, 
+    this.stdinBuffer_.readableStream,
     this.stdoutBuffer_.writableStream,
-    this.stderrBuffer_.writableStream);
+    this.stderrBuffer_.writableStream,
+    this.ttyinBuffer_.readableStream,
+    this.ttyoutBuffer_.writableStream);
 };
 
 export default StdioSource;


### PR DESCRIPTION
These streams can be used when stdin/stdout are piped, e.g. when using
SSH to create a secure stream to a remote server. In that case
ttyin/ttyout can still be wired to the terminal input and output. In the
case of ssh, this can be used to print the password prompt, and read the
password from the user.

In the normal case, these streams will be unused.
