### PR TITLE
Better error reporting in built-in executables

### DIFF
--- a/lib/axiom/core/error.js
+++ b/lib/axiom/core/error.js
@@ -23,16 +23,19 @@
  * "ok" with a result value or "error" with an Err value.
  *
  * @param {string} name
- * @param {*} value
+ * @param {*=} value
  */
-var AxiomError = function(name, value) {
+var AxiomError = function(name, opt_value) {
   Error.call(this);
 
   // The Error ctor doesn't seem to apply the message argument correctly, so
   // we set it by hand instead.  The message property gives DevTools an
   // informative message to dump for uncaught exceptions.
   /** @const {string} */
-  this.message = name + ': ' + JSON.stringify(value);
+  this.message = name;
+  if (opt_value) {
+    this.message += ': ' + JSON.stringify(opt_value);
+  }
 
   // Similar with the stack property.
   /** @type {string} */
@@ -42,7 +45,7 @@ var AxiomError = function(name, value) {
   this.errorName = name;
 
   /** @const {*} */
-  this.errorValue = value;
+  this.errorValue = opt_value;
 };
 
 export {AxiomError};

--- a/lib/wash/exe/cat.js
+++ b/lib/wash/exe/cat.js
@@ -56,7 +56,7 @@ export var main = function(cx) {
         var errorString;
 
         if (e instanceof AxiomError) {
-          errorString = e.errorName;
+          errorString = e.message;
         } else {
           errorString = e.toString();
         }

--- a/lib/wash/exe/mkdir.js
+++ b/lib/wash/exe/mkdir.js
@@ -50,7 +50,7 @@ export var main = function(cx) {
       var errorString;
 
       if (e instanceof AxiomError) {
-        errorString = e.errorName;
+        errorString = e.message;
       } else {
         errorString = e.toString();
       }

--- a/lib/wash/exe/rm.js
+++ b/lib/wash/exe/rm.js
@@ -50,7 +50,7 @@ export var main = function(cx) {
       var errorString;
 
       if (e instanceof AxiomError) {
-        errorString = e.errorName;
+        errorString = e.message;
       } else {
         errorString = e.toString();
       }

--- a/lib/wash/exe/touch.js
+++ b/lib/wash/exe/touch.js
@@ -55,7 +55,7 @@ export var main = function(cx) {
       var errorString;
 
       if (e instanceof AxiomError) {
-        errorString = e.errorName;
+        errorString = e.message;
       } else {
         errorString = e.toString();
       }


### PR DESCRIPTION
@rpaquay 

Before this change, just the error name would be printed with no further details.
