### PR TITLE
Fixed closure annotations

### DIFF
--- a/lib/wash/exe/import.js
+++ b/lib/wash/exe/import.js
@@ -37,7 +37,8 @@ export var main = function(cx) {
   var list = cx.getArg('_', []);
   if (list.length > 1 || cx.getArg('help')) {
     cx.stdout.write(IMPORT_CMD_USAGE_STRING + '\n');
-    return cx.closeOk();
+    cx.closeOk();
+    return;
   }
 
   /** @type {string} */
@@ -137,7 +138,6 @@ ImportCommand.prototype.handleFileSelect_ = function(evt) {
   /** @type {FileList} */
   var files = evt.target.files;
 
-  /** @type {Array<Promise>} */
   var copyPromises = [];
 
   for (var i = 0, f; f = files[i]; i++) {
@@ -156,7 +156,7 @@ ImportCommand.prototype.handleFileSelect_ = function(evt) {
 
     /** @type {{path:Path, completer:Completer}} */
     reader.onload = function(data, evt) {
-      /** @type {string} */
+      /** @type {ArrayBuffer|Blob|null|string} */
       var fileContent = reader.result;
 
       /** @type {Path} */


### PR DESCRIPTION
Fixes several closure-compiler complaints introduced in import dialog #115.

@ussuri This fixes all closure-compiler complaints.  There is still one left for `mv`.

I had to remove the type annotation for `copyPromises` because I couldn't find an annotation which would work with `Promise.all` and it looked like that was what was done in other code.
