### PR TITLE
Remove `onError` event, fire `onClose` in all cases.

### DIFF
--- a/lib/axiom/core/ephemeral.js
+++ b/lib/axiom/core/ephemeral.js
@@ -57,9 +57,6 @@ export var Ephemeral = function() {
   this.onReset = new AxiomEvent();
 
   /** @const @type {!AxiomEvent} */
-  this.onError = new AxiomEvent();
-
-  /** @const @type {!AxiomEvent} */
   this.onClose = new AxiomEvent();
 
   this.reset();
@@ -105,11 +102,10 @@ Ephemeral.prototype.reset = function() {
 
       if (this.readyState == Ephemeral.State.Ready) {
         this.readyState = Ephemeral.State.Closed;
-        this.onClose.fire(this.closeReason, rejectValue);
       } else {
         this.readyState = Ephemeral.State.Error;
-        this.onError.fire(rejectValue);
       }
+      this.onClose.fire(this.closeReason, rejectValue);
     }.bind(this));
 
   this.onReset.fire(this.ephemeralPromise);


### PR DESCRIPTION
One (wanted) side effect of this is that the `setCallee` method will cleanup the `ExecuteContext.callee` property in all cases of completion. Before this change, the `callee` member would not be cleaned up if a command would `reject`/`closeError` before calling `cx.ready`.

TBR @rginda 
