### PR TITLE
Fix a few nodefs bugs

### DIFF
--- a/lib/axiom/fs/node/execute_context.js
+++ b/lib/axiom/fs/node/execute_context.js
@@ -32,18 +32,21 @@ var NodeFileSystem;
  * @param {!NodeFileSystem} nodefs
  * @param {!Stdio} stdio
  * @param {Path} path
- * @param {Object|Arguments} arg
+ * @param {Arguments} arg
  */
-export var NodeExecuteContext = function(nodefs, stdio, path, arg) {
-  this.nodefs = nodefs;
-  this.stdio = stdio;
-  this.path = path;
-  this.arg = arg;
+export var NodeExecuteContext = function(nodefs, stdio, path, args) {
+  ExecuteContext.call(this, nodefs, stdio, path, args);
 };
 
 export default NodeExecuteContext;
 
-NodeExecuteContext.prototype.execute_ = function() {
-  return Promise.reject(new AxiomError(
-      'NotImplemented', 'Node filesystem is not yet executable.'));
+NodeExecuteContext.prototype = Object.create(ExecuteContext.prototype);
+
+/**
+ * @override
+ * @return {!Promise<*>}
+ */
+NodeExecuteContext.prototype.execute = function() {
+  return Promise.reject(
+      new AxiomError.NotImplemented('Node file system is not yet executable.'));
 };

--- a/lib/axiom/fs/node/file_system.js
+++ b/lib/axiom/fs/node/file_system.js
@@ -65,19 +65,6 @@ NodeFileSystem.available = function() {
 /**
  * @private
  * @param {Path} path
- * @return {string}
- */
-NodeFileSystem.makeNodefsPath_ = function(path) {
-  if (!path || !path.relSpec)
-    return '/';
-
-  // path.relSpec always start with a '/'
-  return path.relSpec;
-};
-
-/**
- * @private
- * @param {Path} path
  * @return {!boolean}
  */
 NodeFileSystem.prototype.isValidPath_ = function(path) {
@@ -112,7 +99,7 @@ NodeFileSystem.prototype.resolve = function(path) {
   //TODO(grv): resolve directories and read mode bits.
   var nodefs = this.nodefs;
   return new Promise(function(resolve, reject) {
-    nodefs.root.getFile(NodeFileSystem.makeNodefsPath_(path),
+    nodefs.root.getFile(nodefsUtil.makeNodefsPath(path),
         {create: true}, resolve, reject);
   });
 };
@@ -133,7 +120,7 @@ NodeFileSystem.prototype.stat = function(path) {
       }
       return resolve(nodefsUtil.mapStat(stat));
     };
-    this.nodefs.stat(NodeFileSystem.makeNodefsPath_(path), statCb);
+    this.nodefs.stat(nodefsUtil.makeNodefsPath(path), statCb);
   }.bind(this));
 };
 
@@ -168,7 +155,7 @@ NodeFileSystem.prototype.mkdir = function(path) {
       }
     };
 
-    this.nodefs.mkdir(NodeFileSystem.makeNodefsPath_(path), cb);
+    this.nodefs.mkdir(nodefsUtil.makeNodefsPath(path), cb);
   }.bind(this));
 };
 
@@ -220,7 +207,7 @@ NodeFileSystem.prototype.unlink = function(path) {
     return Promise.reject(new AxiomError.Invalid('path', path.originalSpec));
 
   return new Promise(function(resolve, reject) {
-    this.nodefs.unlink(NodeFileSystem.makeNodefsPath_(path), function(err) {
+    this.nodefs.unlink(nodefsUtil.makeNodefsPath(path), function(err) {
       if (err) {
         return reject(err);
       } else {
@@ -239,8 +226,7 @@ NodeFileSystem.prototype.list = function(path) {
   if (!this.isValidPath_(path))
     return Promise.reject(new AxiomError.Invalid('path', path.originalSpec));
 
-  return nodefsUtil.listDirectory(
-      this.nodefs, NodeFileSystem.makeNodefsPath_(path)).then(
+  return nodefsUtil.listDirectory(this.nodefs, path).then(
     function(entries) {
       return Promise.resolve(entries);
     });

--- a/lib/axiom/fs/node/nodefs_util.js
+++ b/lib/axiom/fs/node/nodefs_util.js
@@ -19,21 +19,28 @@ import AxiomError from 'axiom/core/error';
 export var nodefsUtil = {};
 export default nodefsUtil;
 
-nodefsUtil.joinPath = function(path, relSpec) {
-  if (!path)
-    return '/' + relSpec;
+/**
+ * Convert a Path instance into a string that can be used as an abolute path
+ * for calling into the node fs module.
+ *
+ * @param {Path} path
+ * @return {!string}
+ */
+nodefsUtil.makeNodefsPath = function(path) {
+  if (!path || !path.isValid)
+    throw new AxiomError.Invalid('path', path.originalSpec);
 
-  if (path == '/')
-    return path + relSpec;
-
-  return path + '/' + relSpec;
+  // Note: path.relSpec always start with a '/', so it is compatible with node
+  // fs paths. When we support Windows drive letters, there will be some actual
+  // string conversion to be made.
+  return path.relSpec;
 };
 
 /**
- * List all FileEntrys in a given nodefs directory.
+ * List all file entries in a given nodefs directory.
  *
  * @param {!*} fs node filesystem.
- * @param {!string} path The absolute path of the target directory.
+ * @param {Path} path Path of the target directory.
  * @return {!Promise<!Object<!string, !StatResult>>} A object where keys are
  *  file/directory names and values are StatResult instances.
  */
@@ -46,11 +53,12 @@ nodefsUtil.listDirectory = function(fs, path) {
 
       var rv = {};
       var statFile = function(file) {
-        var filePath = nodefsUtil.joinPath(path, file);
+        var filePath = path.combine(file);
         return nodefsUtil.statPath(fs, filePath).then(function(statResult) {
           rv[file] = statResult;
         }).catch(function(e) {
           // Skip files that we can't get 'stat' for
+          // TODO(rpaquay) Add support for returning incomplete stat result.
         });
       }
 
@@ -64,13 +72,13 @@ nodefsUtil.listDirectory = function(fs, path) {
         resolve(rv);
       }).catch(reject);
     };
-    fs.readdir(path, cb);
+    fs.readdir(nodefsUtil.makeNodefsPath(path), cb);
   });
 };
 
 /**
  * @param {!*} fs node filesystem.
- * @param {!string} path Path to the node file system entry.
+ * @param {!Path} path Path to the node file system entry.
  * @return {!Promise<!StatResult>}
  */
 nodefsUtil.statPath = function(fs, path) {
@@ -80,13 +88,13 @@ nodefsUtil.statPath = function(fs, path) {
         return reject(err);
       resolve(nodefsUtil.mapStat(stat));
     };
-    fs.stat(path, cb);
+    fs.stat(nodefsUtil.makeNodefsPath(path), cb);
   });
 };
 
 /**
- * @param {Object} stat  node fs stat object
- * @return {StatResult}
+ * @param {!Object} stat  node fs stat object
+ * @return {!StatResult}
  */
 nodefsUtil.mapStat = function(stat) {
   var stat_new = new StatResult({});

--- a/lib/axiom/fs/node/open_context.js
+++ b/lib/axiom/fs/node/open_context.js
@@ -41,14 +41,22 @@ var OpenMode;
 export var NodeOpenContext = function(nodefs, path, mode) {
   OpenContext.call(this, nodefs, path, mode);
 
-  this.pathSpec = '/' + path.relSpec;
+  /** The node fs version of the Path instance.
+   * @type {!string}
+   */
+  this.nodefsPath = nodefsUtil.makeNodefsPath(path);
 
-  // The Node FileEntry we're operation on.
+  /**
+   * The Node FileEntry we're operation on.
+   * @type {*}
+   */
   this.entry_ = null;
 
-  // The Node fd we're operating on.
+  /**
+   * The Node fd we're operating on.
+   * @type {?number}
+   */
   this.fd = null;
-
 };
 
 export default NodeOpenContext;
@@ -92,7 +100,7 @@ NodeOpenContext.prototype.convertModeToString_ = function(mode) {
 NodeOpenContext.prototype.seek = function(offset, whence) {
   return OpenContext.prototype.seek.call(this, offset, whence).then(function() {
     return Promise.reject(
-        new AxiomError.TypeMismatch('seekable', this.pathSpec));
+        new AxiomError.TypeMismatch('seekable', this.nodefsPath));
   }.bind(this));
 };
 
@@ -107,26 +115,27 @@ NodeOpenContext.prototype.seek = function(offset, whence) {
 NodeOpenContext.prototype.open = function() {
   return OpenContext.prototype.open.call(this).then(function() {
     return new Promise(function(resolve, reject) {
-      this.fileSystem.fileSystem.exists(this.pathSpec, function(exists) {
+      // TODO: Catch error and/or make async call
+      this.fileSystem.nodefs.exists(this.nodefsPath, function(exists) {
         if (!exists && !this.mode.create) {
           return reject(
-              new AxiomError.Invalid('Invalid path: ', this.pathSpec));
+              new AxiomError.Invalid('Invalid path: ', this.path.spec));
         } else if (this.mode.exclusive) {
           return reject(
-              new AxiomError.Invalid('Invalid path: ', this.pathSpec));
+              new AxiomError.Invalid('Invalid path: ', this.path.spec));
         }
 
-        var stats = this.fileSystem.fileSystem.statSync(this.pathSpec);
+      // TODO: Catch error and/or make async call
+        var stats = this.fileSystem.nodefs.statSync(this.nodefsPath);
 
         if (stats.isDirectory()) {
           return reject(
-              new AxiomError.Invalid('Invalid path: ', this.pathSpec));
+              new AxiomError.Invalid('Invalid path: ', this.path.spec));
         }
 
         var mode = this.convertModeToString_(this.mode);
 
-        this.fileSystem.fileSystem.open(
-            this.pathSpec, mode, function(err, fd) {
+        this.fileSystem.nodefs.open(this.nodefsPath, mode, function(err, fd) {
           if (err) {
             return reject(err);
           }
@@ -199,11 +208,11 @@ NodeOpenContext.prototype.write = function(offset, whence, dataType, data) {
        return reject(
           new AxiomError.NotImplemented(dataType + ': not supportd.'));
      }
-     this.fileSystem.fileSystem.writeFile(this.pathSpec, data, function(err) {
+     this.fileSystem.nodefs.writeFile(this.nodefsPath, data, function(err) {
        if (err) {
          return reject(err);
        } else {
-           return resolve(writeResult);
+         return resolve(writeResult);
        }
      });
     }.bind(this));


### PR DESCRIPTION
- nodefs modes were not mapped properly to Path.mode.
- Too many '/' at the start of paths.
- Fatal error when listing directory entries that are not accessible (EPERM exception from call to statSync). Instead, we skip those entries.
- Add missing closure annotations.
- See bug #132

@gaurave 
fyi: @rginda 
