### PR TITLE
stdout redirection in command lines

### DIFF
--- a/lib/wash/exe/wash.js
+++ b/lib/wash/exe/wash.js
@@ -480,7 +480,8 @@ Wash.prototype.parseShellInput = function(str) {
     path = pwd + '/' + path.substr(2);
   }
 
-  if ((redirMode && !redirPath) || redirPath.indexOf('>') !== -1) {
+  if ((redirMode && !redirPath) ||
+      (redirPath && redirPath.indexOf('>') !== -1)) {
     throw new AxiomError.Invalid('stdout-redirection', str);
   }
 


### PR DESCRIPTION
@rpaquay 

E.g. `cmd arg1 arg2 > out.txt`.

Next up: `cmd1 | cmd2 | cmd3 > out.txt`.

Fixes #129
