### PR TITLE
Add native same-FS copy + refactor copy/move logic + add default copy/move to FileSystem

### DIFF
--- a/lib/axiom/fs/base/file_system.js
+++ b/lib/axiom/fs/base/file_system.js
@@ -134,8 +134,32 @@ FileSystem.prototype.mkdir = function(path) {
  * @param {Path} toPath
  * @return {!Promise<undefined>}
  */
+FileSystem.prototype.copy = function(fromPath, toPath) {
+  return this.readFile(fromPath)
+    .then(function(readResult) {
+      return this.writeFile(toPath, readResult.dataType, readResult.data);
+    }.bind(this));
+};
+
+/**
+ * Move an entry from a path on a file system to a different path on the
+ * same file system.
+ *
+ * The destination path must refer to a file that does not yet exist, inside a
+ * directory that does.
+ *
+ * @param {Path} fromPath
+ * @param {Path} toPath
+ * @return {!Promise<undefined>}
+ */
 FileSystem.prototype.move = function(fromPath, toPath) {
-  abstract();
+  return this.readFile(fromPath)
+    .then(function(readResult) {
+      return this.writeFile(toPath, readResult.dataType, readResult.data);
+    }.bind(this))
+    .then(function() {
+      return this.unlink(fromPath);
+    }.bind(this));
 };
 
 /**

--- a/lib/axiom/fs/base/file_system_manager.js
+++ b/lib/axiom/fs/base/file_system_manager.js
@@ -171,6 +171,49 @@ FileSystemManager.prototype.mkdir = function(path) {
 };
 
 /**
+ * @private
+ * @param {Path} fromPath
+ * @param {Path} toPath
+ * @param {isMove} Whether the operation to do is move (vs. copy).
+ * @return {!Promise<undefined>}
+ */
+FileSystemManager.prototype.copyOrMove_ = function(fromPath, toPath, isMove) {
+  var fromFs = this.getFileSystem_(fromPath);
+  var toFs = this.getFileSystem_(toPath);
+  var promise;
+  if (fromFs == toFs) {
+    promise = isMove ? 
+        fromFs.move(fromPath, toPath) : 
+        fromFs.copy(fromPath, toPath);
+  } else {
+    promise = fromFs.readFile(fromPath)
+      .then(function(readResult) {
+        return toFs.writeFile(toPath, readResult.dataType, readResult.data);
+      })
+      .then(function() {
+        return isMove ? fromFs.unlink(fromPath) : Promise.resolve();
+      });
+  }
+  return promise;
+};
+
+/**
+ * Copy an entry from a path on a file system to a different path on the
+ * same file system.
+ *
+ * The destination path must refer to a file that does not yet exist, inside a
+ * directory that does.
+ *
+ * @override
+ * @param {Path} fromPath
+ * @param {Path} toPath
+ * @return {!Promise<undefined>}
+ */
+FileSystemManager.prototype.copy = function(fromPath, toPath) {
+  return this.copyOrMove_(fromPath, toPath, false);
+};
+
+/**
  * Move an entry from a path on a file system to a different path on the
  * same file system.
  *
@@ -183,8 +226,7 @@ FileSystemManager.prototype.mkdir = function(path) {
  * @return {!Promise<undefined>}
  */
 FileSystemManager.prototype.move = function(fromPath, toPath) {
-  var fileSystem = this.getFileSystem_(fromPath);
-  return fileSystem.move(fromPath, toPath);
+  return this.copyOrMove_(fromPath, toPath, true);
 };
 
 /**

--- a/lib/axiom/fs/gdrive/file_system.js
+++ b/lib/axiom/fs/gdrive/file_system.js
@@ -167,6 +167,19 @@ GDriveFileSystem.prototype.alias = function(fromPath, toPath) {
  * @param {Path} toPath
  * @return {!Promise<undefined>}
  */
+GDriveFileSystem.prototype.copy = function(fromPath, toPath) {
+  this.validatePaths_(fromPath, toPath);
+  return this.refreshOnline().then(function() {
+    return gdrivefsUtil.copyEntry(fromPath, toPath);
+  });
+};
+
+/**
+ * @override
+ * @param {Path} fromPath
+ * @param {Path} toPath
+ * @return {!Promise<undefined>}
+ */
 GDriveFileSystem.prototype.move = function(fromPath, toPath) {
   this.validatePaths_(fromPath, toPath);
   return this.refreshOnline().then(function() {

--- a/lib/axiom/fs/js/file_system.js
+++ b/lib/axiom/fs/js/file_system.js
@@ -228,6 +228,16 @@ JsFileSystem.prototype.alias = function(pathFrom, pathTo) {
  * @param {Path} toPath
  * @return {!Promise<undefined>}
  */
+JsFileSystem.prototype.copy = function(fromPath, toPath) {
+  return this.alias(fromPath, toPath);
+};
+
+/**
+ * @override
+ * @param {Path} fromPath
+ * @param {Path} toPath
+ * @return {!Promise<undefined>}
+ */
 JsFileSystem.prototype.move = function(fromPath, toPath) {
   return this.alias(fromPath, toPath).then(
     function() {

--- a/lib/wash/exe/cp.js
+++ b/lib/wash/exe/cp.js
@@ -33,7 +33,14 @@ export var main = function(cx) {
       '',
       'If the destination file is a directory, the source file will be copied',
       'using the same name.  This doe not support recursive directory copies',
-      'or multiple source files as of yet.'
+      'or multiple source files as of yet.',
+  	  '',
+      'If both locations are on the same file system this will try to perform ',
+      'an atomic native copy, if available, which will preserve the file\'s ',
+      'native format and most of its attributes, such as permissions.  ',
+      'If not, the command will read the contents of the source file, ',
+      'possibly with format conversion, and write it to a newly created ',
+      'destination file.'
     ].join('\r\n') + '\r\n');
     cx.closeOk();
     return;
@@ -51,15 +58,12 @@ export var main = function(cx) {
   /** @type {Path} */
   var toPath = Path.abs(pwd, toPathSpec);
 
-  var fileSystem = cx.fileSystemManager;
-
-  fileSystem.readFile(fromPath).then(function(readResult) {
-    return fileSystem.writeFile(toPath, readResult.dataType, readResult.data);
-  }).then(function() {
-    cx.closeOk();
-  }).catch(function(error) {
-    cx.closeError(error);
-  });
+  cx.fileSystemManager.copy(fromPath, toPath)
+    .then(function() {
+      cx.closeOk();
+    }).catch(function(err) {
+      cx.closeError(err);
+    });
 };
 
 export default main;

--- a/lib/wash/exe/mv.js
+++ b/lib/wash/exe/mv.js
@@ -32,7 +32,8 @@ export var main = function(cx) {
       'Move a file to a new location.',
       '',
       'If both locations are on the same file system this will perform an',
-      'atomic move.  If not, it\'ll perform a copy and delete.'
+      'atomic move.  If not, it\'ll perform a copy and delete (see `cp -h` ',
+      'for the details on how copying works).'
     ].join('\r\n') + '\r\n');
     cx.closeOk();
     return;
@@ -50,23 +51,7 @@ export var main = function(cx) {
   /** @type {Path} */
   var toPath = Path.abs(pwd, toPathSpec);
 
-  var fs = cx.fileSystemManager;
-
-  /** @type {Promise<undefined>} */
-  var promise;
-
-  if (fromPath.root === toPath.root) {
-    promise = fs.move(fromPath, toPath);
-  } else {
-    promise =
-        fs.readFile(fromPath).then(function(readResult) {
-          return fs.writeFile(toPath, readResult.dataType, readResult.data);
-        }).then(function() {
-          return fs.unlink(fromPath);
-        });
-  }
-
-  promise
+  cx.fileSystemManager.move(fromPath, toPath)
     .then(function() {
       cx.closeOk();
     }).catch(function(err) {


### PR DESCRIPTION
@rpaquay: code
@rginda: updated help in cp.js and mv.js

* Add a FileSystem.prototype.copy() stub, similar to move().
* Implement a native copy() for GDriveFileSystem.
* Move the copy/move logic from cp.js/mv.js to FileSystem (for same-FS) and FileSystemManager (for cross-FS, while delegating to FileSystem for same-FS).
* The above also means that any FileSystem now has at least a generic copy/move (e.g. DomFileSystem didn't have either before).