### PR TITLE
cd: report error on bad dir instead of hanging

### DIFF
--- a/lib/wash/exe/wash.js
+++ b/lib/wash/exe/wash.js
@@ -148,7 +148,9 @@ Wash.builtins = {
           wash.executeContext.setEnv('$PWD', path.spec);
           cx.closeOk();
         }
-      );
+      ).catch(function(err) {
+        cx.closeError(err);
+      });
     }
   ],
 


### PR DESCRIPTION
TODO: we munge NotFound errors in the dispatch() function in a
way that causes us to report that the "cd" command was not
found, rather than the invalid directory.  Fix for that will
come soon.

TBR @rpaquay 