### PR TITLE
Close cx on error

### DIFF
--- a/lib/axiom/fs/js/executable.js
+++ b/lib/axiom/fs/js/executable.js
@@ -69,8 +69,11 @@ JsExecutable.prototype.execute = function(cx) {
 
   try {
     ret = this.callback_(cx);
-  } catch (ex) {
-    console.log(ex);
+  } catch (err) {
+    // Note: In case a command implementation throws instead of returning a
+    // rejected promise, close the execution context with the error caught.
+    cx.closeError(err);
+    return cx.ephemeralPromise;
   }
 
   if (typeof ret !== 'undefined') {


### PR DESCRIPTION
* In general, this makes invoking an executable more robust by closing the context if the executable throws an exception.

* In particular, this fixes the issue where `cd` hangs when using an unknown file system name (e.g. `cd foo:`)

@ussuri 