### PR TITLE
Send Ctrl-C keystroke to signal stream.

### DIFF
--- a/bin/wash.js
+++ b/bin/wash.js
@@ -58,8 +58,11 @@ function startWash(fsm) {
       });
 
       process.stdin.on('data', function(buffer) {
-        if (buffer == '\x03')
-          cx.closeError(new AxiomError.Interrupt());
+        // Ctrl-C
+        if (buffer == '\x03') {
+          stdioSource.signal.write({name: 'interrupt'});
+          return;
+        }
 
         stdioSource.stdin.write(buffer.toString());
       });


### PR DESCRIPTION
This is to match the (correct) web_shell terminal behavior

@ussuri 