### PR TITLE
`mount`: print usage help when user attempts to use free args

### DIFF
--- a/lib/wash/exe/mount.gdrive.js
+++ b/lib/wash/exe/mount.gdrive.js
@@ -26,9 +26,11 @@ var FileSystemManager;
  * @return {void}
  */
 export var main = function(cx) {
-  if (document.location.protocol !== 'http:') {
+  if (document.location.protocol !== 'https:') {
     cx.closeError(new AxiomError.Incompatible(
-        'connection protocol', 'gdrive file system requires HTTPS connection'));
+        'connection protocol',
+        'gdrive file system requires HTTPS connection, not ' +
+            document.location.protocol));
     return;
   }
 

--- a/lib/wash/exe/mount.js
+++ b/lib/wash/exe/mount.js
@@ -30,7 +30,7 @@ var FileSystemManager;
 export var main = function(cx) {
   cx.ready();
 
-  if (cx.getArg('help')) {
+  if (cx.getArg('help') || cx.getArg('_')) {
     cx.stdout.write([
       'usage: mount [-t|--type <type>] [-n|--name <name>]',
       'List mounted filesystems, or mount a new file system.',
@@ -102,7 +102,8 @@ var mountFileSystem_ = function(cx) {
 main.signature = {
   'help|h': '?',
   'type|t': '$',
-  'name|n': '$'
+  'name|n': '$',
+  '_': '@'
 };
 
 export default main;


### PR DESCRIPTION
@rpaquay 

Missing '_' in signature wasn't enough to prevent the user from trying to use the command with a free argument, e.g. `mount gdrive`. The command would behave as if no free args were provided at all, that is print a list of mounted systems.