### PR TITLE
Add support for downloading and running closure compiler locally.

### DIFF
--- a/gruntfile.js
+++ b/gruntfile.js
@@ -34,6 +34,15 @@ module.exports = function(grunt) {
       all: ['tmp', 'dist']
     },
 
+    // Install closure compiler locally
+    'closure-compiler-build': {
+      build: {
+        url: 'http://dl.google.com/closure-compiler/compiler-20150126.zip',
+        dir: 'node_modules/grunt-closure-compiler-build/build/',
+        filename: 'compiler.zip'
+      }
+    },
+
     'closure-compiler': {
       check: {
         cwd: 'lib/',
@@ -48,7 +57,10 @@ module.exports = function(grunt) {
              '../tmp/third_party/dcodeIO/events.js'
             ],
         jsOutputFile: 'tmp/closure/out.js',
-        options: require('./build/closure-options.json')
+        options: require('./build/closure-options.json'),
+        closurePath: process.env.CLOSURE_PATH ?
+            process.env.CLOSURE_PATH :
+            '../node_modules/grunt-closure-compiler-build'
       }
     },
 
@@ -393,6 +405,9 @@ module.exports = function(grunt) {
       main: {}
     }
   });
+
+  // Install local copy of closure compiler.
+  grunt.registerTask('closure_install', ['closure-compiler-build']);
 
   // Make the generated files.
   grunt.registerTask('make_generated', ['closure_externs',

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "es6-promise": "^2.0.1",
     "grunt": "^0.4.5",
     "grunt-closure-compiler": "0.0.21",
+    "grunt-closure-compiler-build": "^1.0.1",
     "grunt-contrib-clean": "~0.5.0",
     "grunt-contrib-concat": "~0.5.0",
     "grunt-contrib-copy": "^0.6.0",


### PR DESCRIPTION
This will help with running grunt check on drone.io

TBR @ussuri 