### PR TITLE
Assorted small fixes

### DIFF
--- a/README-pages.md
+++ b/README-pages.md
@@ -1,5 +1,5 @@
 Deploying sample to GitHub Pages (gh-pages branch):
 
 1. Generate SSH keys for passwordless pushing to github (see https://help.github.com/articles/generating-ssh-keys/ )
-2. Run grunt deploy_samples - This will build the samples web app and deploy it to github pages:
+2. Run grunt piblish_samples - This will build the samples web app and deploy it to github pages:
 3. Browse to samples at: http://chromium.github.io/axiom

--- a/lib/axiom/core/completer.js
+++ b/lib/axiom/core/completer.js
@@ -17,7 +17,7 @@
  * @template T
  */
 export var Completer = function() {
-  /** @type {function(T)} */
+  /** @type {function(T=)} */
   this.resolve = function() {};
 
   /** @type {function(*)} */
@@ -25,7 +25,7 @@ export var Completer = function() {
 
   /** @type {!Promise<T>} */
   this.promise = new Promise(
-    function(/** function(T) */ resolve, /** function(*) */ reject) {
+    function(/** function(T=) */ resolve, /** function(*) */ reject) {
       this.resolve = resolve;
       this.reject = reject;
     }.bind(this));

--- a/lib/axiom/fs/base/execute_context.js
+++ b/lib/axiom/fs/base/execute_context.js
@@ -169,7 +169,7 @@ ExecuteContext.prototype.execute = function() {
  * If the callee is closed, events are rerouted back to this instance and the
  * callee instance property is set to null.
  *
- * @param {ExecuteContext} executeContext
+ * @param {!ExecuteContext} executeContext
  * @return {void}
  */
 ExecuteContext.prototype.setCallee = function(executeContext) {
@@ -405,6 +405,5 @@ ExecuteContext.prototype.dispatchSignal = function(signal) {
     }
 
     this.closeError(new AxiomError.Interrupt());
-    return;
   }
 };

--- a/lib/axiom/fs/nested_stdio.js
+++ b/lib/axiom/fs/nested_stdio.js
@@ -48,4 +48,3 @@ NestedStdio.prototype.close = function() {
   this.stdin.close();
   this.signal.close();
 };
-

--- a/lib/axiom/fs/stdio.js
+++ b/lib/axiom/fs/stdio.js
@@ -47,3 +47,11 @@ export var Stdio = function(stdin, stdout, stderr, signal, ttyin, ttyout) {
 };
 
 export default Stdio;
+
+/**
+ * @return {!Stdio}
+ */
+Stdio.prototype.clone = function() {
+ return new Stdio(
+    this.stdin, this.stdout, this.stderr, this.signal, this.ttyin, this.ttyout);
+};

--- a/lib/axiom/fs/stream/writable_memory_stream.js
+++ b/lib/axiom/fs/stream/writable_memory_stream.js
@@ -21,8 +21,8 @@ var WritableStream;
 /** @typedef MemoryStreamBuffer$$module$axiom$fs$stream$memory_stream_buffer */
 var MemoryStreamBuffer;
 
-/** @typedef function():void */
-var EventCallback;
+/** @typedef WriteCallback$$module$axiom$fs$stream$writable_stream */
+var WriteCallback;
 
 /**
  * Event value + associated callback
@@ -54,7 +54,7 @@ WritableMemoryStream.prototype = Object.create(AxiomStream.prototype);
  *
  * @override
  * @param {!*} value
- * @param {EventCallback=} opt_callback
+ * @param {WriteCallback=} opt_callback
  * @return {void}
  */
 WritableMemoryStream.prototype.write = function(value, opt_callback) {

--- a/lib/axiom/fs/stream/writable_stream.js
+++ b/lib/axiom/fs/stream/writable_stream.js
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 /** @typedef function():void */
-var WriteCallback;
+export var WriteCallback;
 
 /**
  * Interface similar to node.js writable stream.

--- a/lib/wash/exe/readline.js
+++ b/lib/wash/exe/readline.js
@@ -201,11 +201,13 @@ Readline.prototype.read = function(inputHistory) {
 
   this.previousLineHeight_ = 0;
 
-  this.print('%get-row-column()');
-
   // Hook up reading from stdin.
   this.executeContext.stdin.pause();
   this.executeContext.stdin.onReadable.addListener(this.readStdIn_, this);
+
+  // Print a request.
+  this.print('%get-row-column()');
+  // Read back and handle a response.
   this.readStdIn_();
 
   this.done_ = false;

--- a/lib/wash/exe/wash.js
+++ b/lib/wash/exe/wash.js
@@ -304,6 +304,7 @@ Wash.prototype.executeWashrc = function() {
 
 /**
  * @param {string} name
+ * @return {!Promise<Array>}
  */
 Wash.prototype.loadFile = function(name) {
   if (!name) {
@@ -313,7 +314,7 @@ Wash.prototype.loadFile = function(name) {
       new Path(name), DataType.UTF8String).then(
     function(/** ReadResult */ result) {
       try {
-        if (typeof result.data != 'string') {
+        if (typeof result.data !== 'string') {
           return Promise.reject(new AxiomError.TypeMismatch(
               'string', typeof result.data));
         }

--- a/lib/wash/parse.js
+++ b/lib/wash/parse.js
@@ -89,6 +89,10 @@ Parse.prototype.parseArgs = function(signature, opt_defaults) {
         // double-dash parameter
         this.advance(1);
         name = this.parsePattern(/[a-z0-9\-\_]+/ig);
+      } else if (/\s|$/.test(this.ch)) {
+        // loose '-'
+        loose.push('-');
+        return;
       } else {
         name = this.ch;
         this.advance(1);


### PR DESCRIPTION
TBR @gaurave 

Less trivial ones:

* Allow a single `-` as a valid command line loose argument (e.g. see the regular `cat`, which uses `-` as an alias for stdin: `echo something | cat foo.txt bar.txt -`)
* In `readline.js`, `stdin` was paused too late, after a request to the terminal had been printed to it. So if  `stdin` happened to be in flowing mode at that time, the request would go nowhere, the `stdin.read()` call in readStdIn_() would return nothing, and the prompt string wouldn't get printed.