### PR TITLE
Get rid of unnecessary arg in ExecuteContext.call and ExecuteContext.createExecuteContext

### DIFF
--- a/lib/axiom/fs/base/execute_context.js
+++ b/lib/axiom/fs/base/execute_context.js
@@ -216,13 +216,12 @@ ExecuteContext.prototype.setStdio = function(stdio) {
  * Utility method to construct a new ExecuteContext, set it as the callee, and
  * execute it with the given path and arg.
  *
- * @param {!FileSystemManager} fileSystemManager
  * @param {!Path} path
  * @param {Object} arg
  * @return {!Promise<*>}
  */
-ExecuteContext.prototype.call = function(fileSystemManager, path, arg) {
-  return fileSystemManager.createExecuteContext(path, this.stdio, arg).then(
+ExecuteContext.prototype.call = function(path, arg) {
+  return this.createExecuteContext(path, this.stdio, arg).then(
     function(cx) {
       this.setCallee(cx);
       return cx.execute();
@@ -357,12 +356,12 @@ ExecuteContext.prototype.delEnv = function(name) {
  * context, bound to the lifetime of this context.
  *
  * @param {!Path} path
+ * @param {!Stdio} stdio
  * @param {Object} arg
  * @return {Promise<ExecuteContext>}
  */
-ExecuteContext.prototype.createExecuteContext = function(path, arg) {
-  return this.fileSystemManager.createExecuteContext(
-      path, this.stdio, arg).then(
+ExecuteContext.prototype.createExecuteContext = function(path, stdio, arg) {
+  return this.fileSystemManager.createExecuteContext(path, stdio, arg).then(
     function(cx) {
       cx.dependsOn(this);
       return cx;

--- a/lib/wash/exe/eval.js
+++ b/lib/wash/exe/eval.js
@@ -155,7 +155,6 @@ Eval.prototype.read = function(promptString) {
   return washUtil.findExecutable(this.executeContext, 'readline').then(
     function(result) {
       return this.executeContext.call(
-          this.executeContext.fileSystemManager,
           result.path,
           { 'prompt-string': promptString,
             'input-history': this.inputHistory

--- a/lib/wash/exe/mount.js
+++ b/lib/wash/exe/mount.js
@@ -92,7 +92,7 @@ var mountFileSystem_ = function(cx) {
   if (name)
     arg['name'] = name;
 
-  cx.call(cx.fileSystemManager, fsMountCmd, arg).then(function() {
+  cx.call(fsMountCmd, arg).then(function() {
     cx.closeOk();
   }).catch(function(err) {
     cx.closeError(err);

--- a/lib/wash/exe/wash.js
+++ b/lib/wash/exe/wash.js
@@ -446,7 +446,6 @@ Wash.prototype.read = function() {
   return this.findExecutable('readline').then(
     function(result) {
       return this.executeContext.call(
-          result.fileSystem,
           result.path,
           { 'prompt-string': this.promptString_,
             'input-history': this.inputHistory


### PR DESCRIPTION
TBR @rpaquay 

(pre-committing some independent changes on the io-redirection branch)