### PR TITLE
Change dataType to Utf8 from value in import command.

### DIFF
--- a/lib/wash/exe/import.js
+++ b/lib/wash/exe/import.js
@@ -133,7 +133,7 @@ ImportCommand.prototype.import = function(destination, forceSingleFile) {
     input.setAttribute('webkitdirectory', '');
     input.setAttribute('multiple', '');
   }
-  
+
   input.style.cssText =
       'position: absolute;' +
       'right: 0';
@@ -188,7 +188,7 @@ ImportCommand.prototype.handleFileCancel_ = function(evt) {
   setTimeout(function() {
     if (this.filesChosen_) return;
     this.destroy_();
-    this.cx_.closeError(new AxiomError.Missing('file selection'));    
+    this.cx_.closeError(new AxiomError.Missing('file selection'));
   }.bind(this), 100);
 }
 
@@ -225,7 +225,7 @@ ImportCommand.prototype.handleFileSelect_ = function(evt) {
       }
       return Promise.reject(e);
     }.bind(this)).then(function(result) {
-      return this.fsm_.writeFile(path, DataType.Value, fileContent);
+      return this.fsm_.writeFile(path, DataType.UTF8String, fileContent);
     }.bind(this)).then(function() {
       fileCompleter.resolve(null);
     }.bind(this)).catch(function(e) {


### PR DESCRIPTION
The dataType was passed as `Value` in import command for the read files. The `domFileSystem` considers `Value` as object and stringyfies them. Change the datatype to be passed as `Utf8`.

This may not be ideal as it will only work for the files which are UTF8 encoded. We need a way to detect the file format and send appropriate dataType.

@rpaquay 