### PR TITLE
Fix mkdir in domfs

### DIFF
--- a/lib/axiom/fs/dom/domfs_util.js
+++ b/lib/axiom/fs/dom/domfs_util.js
@@ -53,11 +53,11 @@ domfsUtil.statEntry = function(entry) {
         });
       }
     };
-    
+
     if ('getMetadata' in entry) {
       entry.getMetadata(
-        onMetadata.bind(null, entry), 
-        function(error) { 
+        onMetadata.bind(null, entry),
+        function(error) {
           if (error.code === 1001) {
             // NOTE: getMetadata() is not implemented for directories in
             // idb.filesystem.js polyfill: it returns an error with this code.
@@ -143,10 +143,11 @@ domfsUtil.remove = function(root, path) {
 /**
  * Create a directory with a given name under root.
  */
-domfsUtil.mkdir = function(root, name) {
+domfsUtil.mkdir = function(root, name, exclusive) {
   return new Promise(function(resolve, reject) {
     var onError = domfsUtil.rejectFileError.bind(null, name, reject);
-    root.getDirectory(name, {create: true, exclusive: true}, resolve, onError);
+    root.getDirectory(name, {create: true, exclusive: exclusive},
+        resolve, onError);
   });
 };
 

--- a/lib/axiom/fs/dom/file_system.js
+++ b/lib/axiom/fs/dom/file_system.js
@@ -103,7 +103,7 @@ DomFileSystem.mount = function(fileSystemManager, fileSystemName, type) {
       storageType = window.PERSISTENT;
       webkitStorage = navigator['webkitPersistentStorage'];
     }
-    
+
     // requestQuota is specific to Chrome: others don't have it.
     if (webkitStorage) {
       webkitStorage.requestQuota(capacity, function(bytes) {
@@ -184,7 +184,7 @@ DomFileSystem.prototype.mkdir = function(path) {
     var targetName = path.getBaseName();
 
     var onDirectoryFound = function(dir) {
-      return domfsUtil.mkdir(dir, targetName).then(function(r) {
+      return domfsUtil.mkdir(dir, targetName, false).then(function(r) {
         return resolve(r);
       }).catch (function(e) {
         return reject(e);

--- a/lib/wash/exe/import.js
+++ b/lib/wash/exe/import.js
@@ -133,7 +133,7 @@ ImportCommand.prototype.import = function(destination, forceSingleFile) {
     input.setAttribute('webkitdirectory', '');
     input.setAttribute('multiple', '');
   }
-  
+
   input.style.cssText =
       'position: absolute;' +
       'right: 0';
@@ -188,7 +188,7 @@ ImportCommand.prototype.handleFileCancel_ = function(evt) {
   setTimeout(function() {
     if (this.filesChosen_) return;
     this.destroy_();
-    this.cx_.closeError(new AxiomError.Missing('file selection'));    
+    this.cx_.closeError(new AxiomError.Missing('file selection'));
   }.bind(this), 100);
 }
 
@@ -225,7 +225,7 @@ ImportCommand.prototype.handleFileSelect_ = function(evt) {
       }
       return Promise.reject(e);
     }.bind(this)).then(function(result) {
-      return this.fsm_.writeFile(path, DataType.Value, fileContent);
+      return this.fsm_.writeFile(path, DataType.UTF8String, fileContent);
     }.bind(this)).then(function() {
       fileCompleter.resolve(null);
     }.bind(this)).catch(function(e) {


### PR DESCRIPTION
Review in order of #222 #223 #224 
This adds `exclusive` option to be passed while calling `domfs_util.mkdir` API. Currently the `domfs.mkdir` sets this option to false by default. We should allow the api to take it as a parameter.

This fixes `import` command for dom-file-system.

@rpaquay 