### PR TITLE
Make service-worker / page connection reliable

### DIFF
--- a/lib/axiom/fs/dom/domfs_util.js
+++ b/lib/axiom/fs/dom/domfs_util.js
@@ -53,11 +53,11 @@ domfsUtil.statEntry = function(entry) {
         });
       }
     };
-    
+
     if ('getMetadata' in entry) {
       entry.getMetadata(
-        onMetadata.bind(null, entry), 
-        function(error) { 
+        onMetadata.bind(null, entry),
+        function(error) {
           if (error.code === 1001) {
             // NOTE: getMetadata() is not implemented for directories in
             // idb.filesystem.js polyfill: it returns an error with this code.
@@ -143,10 +143,11 @@ domfsUtil.remove = function(root, path) {
 /**
  * Create a directory with a given name under root.
  */
-domfsUtil.mkdir = function(root, name) {
+domfsUtil.mkdir = function(root, name, exclusive) {
   return new Promise(function(resolve, reject) {
     var onError = domfsUtil.rejectFileError.bind(null, name, reject);
-    root.getDirectory(name, {create: true, exclusive: true}, resolve, onError);
+    root.getDirectory(name, {create: true, exclusive: exclusive},
+        resolve, onError);
   });
 };
 

--- a/lib/axiom/fs/dom/file_system.js
+++ b/lib/axiom/fs/dom/file_system.js
@@ -103,7 +103,7 @@ DomFileSystem.mount = function(fileSystemManager, fileSystemName, type) {
       storageType = window.PERSISTENT;
       webkitStorage = navigator['webkitPersistentStorage'];
     }
-    
+
     // requestQuota is specific to Chrome: others don't have it.
     if (webkitStorage) {
       webkitStorage.requestQuota(capacity, function(bytes) {
@@ -184,7 +184,7 @@ DomFileSystem.prototype.mkdir = function(path) {
     var targetName = path.getBaseName();
 
     var onDirectoryFound = function(dir) {
-      return domfsUtil.mkdir(dir, targetName).then(function(r) {
+      return domfsUtil.mkdir(dir, targetName, false).then(function(r) {
         return resolve(r);
       }).catch (function(e) {
         return reject(e);

--- a/lib/wash/exe/import.js
+++ b/lib/wash/exe/import.js
@@ -133,7 +133,7 @@ ImportCommand.prototype.import = function(destination, forceSingleFile) {
     input.setAttribute('webkitdirectory', '');
     input.setAttribute('multiple', '');
   }
-  
+
   input.style.cssText =
       'position: absolute;' +
       'right: 0';
@@ -188,7 +188,7 @@ ImportCommand.prototype.handleFileCancel_ = function(evt) {
   setTimeout(function() {
     if (this.filesChosen_) return;
     this.destroy_();
-    this.cx_.closeError(new AxiomError.Missing('file selection'));    
+    this.cx_.closeError(new AxiomError.Missing('file selection'));
   }.bind(this), 100);
 }
 
@@ -225,7 +225,7 @@ ImportCommand.prototype.handleFileSelect_ = function(evt) {
       }
       return Promise.reject(e);
     }.bind(this)).then(function(result) {
-      return this.fsm_.writeFile(path, DataType.Value, fileContent);
+      return this.fsm_.writeFile(path, DataType.UTF8String, fileContent);
     }.bind(this)).then(function() {
       fileCompleter.resolve(null);
     }.bind(this)).catch(function(e) {

--- a/samples/landing/service_worker.js
+++ b/samples/landing/service_worker.js
@@ -49,6 +49,26 @@ function processQueue() {
   }
 };
 
+// Sends a refresh request every 10 seconds to the page, if there is no pending
+// fetch request. Modifies the state to 1 (pending). Thus, even if the connection
+// is broken in between, the fetch requests are queued until the page responds
+// with a new connection. Note that any response from the page is a new connection.
+function messagePoll() {
+  setTimeout(function() {
+   if (!state  && messagePort) {
+     state = 1;
+     var message = {
+       subject: genMessageId(),
+       name: 'refresh'
+     };
+     messagePort.postMessage(message);
+   }
+   messagePoll();
+  }, 10000);
+};
+
+messagePoll();
+
 // Currently it is not possible to initiate post message request from service
 // worker. As a result we send a dummy request from the axiom_web_shell and
 // maintain an open connection. Whenever a fetch event is received by the

--- a/samples/web_shell/lib/shell/service_worker.js
+++ b/samples/web_shell/lib/shell/service_worker.js
@@ -55,6 +55,11 @@ ServiceWorker.prototype.register = function() {
  */
 ServiceWorker.prototype.processMessage = function(message) {
 
+  // An empty message refreshes the connection.
+  if (message.name == 'refresh') {
+    return this.sendMessage(null);
+  }
+
   var path = this.getFileSystemPath(message);
 
   return new Promise(function(resolve, reject) {


### PR DESCRIPTION
Review in order of #222 #223 #224 

The worker pings the page every 10 seconds to refresh the connection, in case there is no pending fetch request. This allows the connection to be active all the time.

However, if the connection is broken from the page side, this will still fail. I will add the message polling on the page side in a follow up PR.

@rpaquay 