### PR TITLE
Eliminate possibility of endless event loop in AxiomEvent.listenOnce

### DIFF
--- a/lib/axiom/core/event.js
+++ b/lib/axiom/core/event.js
@@ -91,8 +91,8 @@ AxiomEvent.prototype.fire_ = function(var_args) {
  */
 AxiomEvent.prototype.listenOnce = function(callback, opt_obj) {
   var listener = function() {
-    callback.apply(opt_obj || null, arguments);
     this.removeListener(listener);
+    callback.apply(opt_obj || null, arguments);
   }.bind(this);
 
   this.addListener(listener);


### PR DESCRIPTION
@umop 

Simplified code:

```
eventA.listenOnce(function() { eventB.fire(); });
eventB.listenOnce(function() { eventA.fire(); });
```

This works with this change, but hangs in an infinite loop without it.