### PR TITLE
Make builtinsFS less special

### DIFF
--- a/lib/axiom/fs/base/file_system_manager.js
+++ b/lib/axiom/fs/base/file_system_manager.js
@@ -52,6 +52,13 @@ export var FileSystemManager = function() {
   this.fileSystems_ = {};
 
   /**
+   * A subset of the known file systems not to be exposed to the end user.
+   * @private
+   * @type {!Object<string, boolean>}
+   */
+  this.hiddenFileSystems_ = {};
+
+  /**
    * The "default" file system, i.e. the first file system mounted.
    * @type {FileSystem}}
    */
@@ -81,12 +88,16 @@ FileSystemManager.prototype.getFileSystem_ = function(path) {
 /**
  * Return the list of currently mounted file systems.
  *
- * @return {Array<FileSystem>}
+ * @param {boolean=} opt_hiddenAlso Whether to return hidden file systems in
+ *    the result.
+ * @return {!Array<FileSystem>}
  */
-FileSystemManager.prototype.getFileSystems = function() {
+FileSystemManager.prototype.getFileSystems = function(opt_hiddenAlso) {
   var result = [];
   for(var key in this.fileSystems_) {
-    result.push(this.fileSystems_[key]);
+    if (opt_hiddenAlso || !this.hiddenFileSystems_[key]) {
+      result.push(this.fileSystems_[key]);
+    }
   }
   return result;
 };
@@ -95,14 +106,17 @@ FileSystemManager.prototype.getFileSystems = function() {
  * Mount a file system. The file system must have a unique name.
  *
  * @param {!FileSystem} fileSystem
+ * @param {boolean=} opt_isHidden Whether this file systems is to be hidden from
+ *    the end user.
  * @return {void}
  */
-FileSystemManager.prototype.mount = function(fileSystem) {
+FileSystemManager.prototype.mount = function(fileSystem, opt_isHidden) {
   if (this.fileSystems_.hasOwnProperty(fileSystem.name)) {
     throw new AxiomError.Duplicate('filesystem-name', fileSystem.name);
   }
 
   this.fileSystems_[fileSystem.name] = fileSystem;
+  this.hiddenFileSystems_[fileSystem.name] = !!opt_isHidden;
   if (!this.defaultFileSystem)
     this.defaultFileSystem = fileSystem;
 };

--- a/lib/wash/exe/wash.js
+++ b/lib/wash/exe/wash.js
@@ -101,8 +101,11 @@ export var Wash = function(executeContext) {
     ];
   }
 
-  this.builtinsFS = new JsFileSystem();
+  this.builtinsFS = new JsFileSystem(this.fileSystemManager, 'builtins');
   this.builtinsFS.rootDirectory.install(builtins);
+  this.fileSystemManager.mount(this.builtinsFS, true);
+  this.executeContext.setEnv('@PATH', 
+      this.executeContext.getEnv('@PATH').concat(['builtins:/']));
 
   if (!this.executeContext.getEnv('$PWD')) {
     this.executeContext.setEnv('$PWD', this.executeContext.getPwd());
@@ -360,47 +363,6 @@ Wash.prototype.setPrompt = function() {
   * @typedef {{fileSystem: !FileSystem, statResult: !StatResult, path: !Path}}
   */
 var FindExecutableResult;
-
-/**
-  * Returns the StatResult of a builtin command given its path, or null if
-  * path does not resolve to a known builtin command.
-  *
-  * @param {!string} pathSpec
-  * @return {!Promise<!FindExecutableResult>}
-  */
-Wash.prototype.findBuiltinOrExecutable = function(pathSpec) {
-  return this.findBuiltin(pathSpec).then(function(result) {
-    if (result) {
-      return Promise.resolve(result);
-    }
-
-    return this.findExecutable(pathSpec);
-  }.bind(this));
-};
-
-/**
-  * Returns the StatResult of a builtin command given its path, or null if
-  * path does not resolve to a known builtin command.
-  *
-  * @param {!string} pathSpec
-  * @return {!Promise<?FindExecutableResult>}
-  */
-Wash.prototype.findBuiltin = function(pathSpec) {
-  var builtinPath = this.builtinsFS.rootPath.combine(pathSpec);
-  return this.builtinsFS.stat(builtinPath).then(
-    function(statResult) {
-      return Promise.resolve({
-        fileSystem: this.builtinsFS,
-        statResult: statResult,
-        path: builtinPath
-      });
-    }.bind(this)
-  ).catch(function(error) {
-    if (AxiomError.NotFound.test(error))
-      return null;
-    return Promise.reject(error);
-  });
-};
 
 /**
  * @param {string} pathSpec


### PR DESCRIPTION
@rpaquay

Give builtinsFS a distinct name (used to be a duplicate 'jsfs') and move it under the main FileSystemManager, but hide it from the end user (e.g. when running `mount`). This eliminates the need for special functions to find the builtins, which also fixes the introduced problem in the redirection PR ( #226 ), where every command entered on the command line is looked up in a universal way inside ExecuteContext.

With this PR, it's possible to manually `cd builtins:/` and see what's available. I think it's a good thing for development, but if not, it can be fixed as well. 