### PR TITLE
Fix Ephemeral to not fire onReset in its ctor

### DIFF
--- a/lib/axiom/core/ephemeral.js
+++ b/lib/axiom/core/ephemeral.js
@@ -59,7 +59,7 @@ export var Ephemeral = function() {
   /** @const @type {!AxiomEvent} */
   this.onClose = new AxiomEvent();
 
-  this.reset();
+  this.init_();
 };
 
 export default Ephemeral;
@@ -72,7 +72,7 @@ Ephemeral.State = {
   Closed: 'Closed'
 };
 
-Ephemeral.prototype.reset = function() {
+Ephemeral.prototype.init_ = function() {
   this.assertEphemeral('Wait', 'Closed', 'Error');
 
   this.readyState = Ephemeral.State.Wait;
@@ -107,7 +107,10 @@ Ephemeral.prototype.reset = function() {
       }
       this.onClose.fire(this.closeReason, rejectValue);
     }.bind(this));
+};
 
+Ephemeral.prototype.reset = function() {
+  this.init_();
   this.onReset.fire(this.ephemeralPromise);
 };
 

--- a/lib/axiom/fs/base/open_context.js
+++ b/lib/axiom/fs/base/open_context.js
@@ -40,7 +40,7 @@ var SeekWhence;
  * A context that represents an open file on a FileSystem.
  *
  * You should only create an OpenContext by calling an instance of
- * FileSystemBinding..createOpenContext(...).
+ * XyzFileSystem.createOpenContext(...).
  *
  * @param {!FileSystem} fileSystem The parent file system.
  * @param {Path} path
@@ -71,6 +71,10 @@ export var OpenContext = function(fileSystem, path, mode) {
    * @private @type {Completer}
    */
   this.openCompleter_ = null;
+  
+  this.onReset.addListener(function() {
+    throw new AxiomError.Runtime('An OpenContext cannot be reset');
+  }.bind(this));
 };
 
 export default OpenContext;


### PR DESCRIPTION
@rpaquay 

Scenario: an `Ephemeral` subclass attaches a handler to `onReset` it its ctor, then calls the base ctor (=> `Ephemeral` ctor). `onReset` fires, and something bad happens.
