### PR TITLE
Fix test failures in JSFS: store data to be written in WriteResult's ctor

### DIFF
--- a/lib/axiom/fs/base/open_context.js
+++ b/lib/axiom/fs/base/open_context.js
@@ -88,7 +88,7 @@ OpenContext.scope = function(cx, promise) {
   return promise(cx).then(
     function(value) {
       cx.closeOk();
-      return Promise.resolve(value)
+      return Promise.resolve(value);
     },
     function(error) {
       cx.closeError(error);
@@ -129,6 +129,7 @@ OpenContext.prototype.seek = function(offset, whence) {
  * Calculates a new seek position based on the current one and the whence/offset
  * combination.
  *
+ * @protected
  * @param {number} offset
  * @param {SeekWhence} whence
  * @param {number} curPos
@@ -145,10 +146,8 @@ OpenContext.prototype.calcSeekPosition = function(
     curPos = dataSize + offset;
   }
 
-  if (curPos < 0 || curPos > dataSize) {
-    throw new AxiomError.OutOfRange(
-        'Requested seek position is outside of data range', curPos);
-  }
+  if (curPos < 0 || curPos > dataSize)
+    throw new AxiomError.OutOfRange('Seek position outside of data', curPos);
   
   return curPos;
 };
@@ -185,5 +184,5 @@ OpenContext.prototype.write = function(offset, whence, dataType, data) {
                                                  this.mode.write));
   }
 
-  return Promise.resolve(new WriteResult(offset, whence, dataType));
+  return Promise.resolve(new WriteResult(offset, whence, dataType, data));
 };

--- a/lib/axiom/fs/stream/stub_file_system.test.js
+++ b/lib/axiom/fs/stream/stub_file_system.test.js
@@ -327,8 +327,7 @@ describe('StubFileSystem', function () {
           function(writeResult) {
             expect(writeResult).toBeDefined();
             expect(writeResult.dataType).toBe(DataType.Value);
-            // TODO(rpaquay): Shoud this be `data` instead?
-            expect(writeResult.data).toBe('This is another text file');
+            expect(writeResult.data).toBe(data);
           }
         );
       }

--- a/lib/axiom/fs/stream/stub_file_system.test.js
+++ b/lib/axiom/fs/stream/stub_file_system.test.js
@@ -328,7 +328,7 @@ describe('StubFileSystem', function () {
             expect(writeResult).toBeDefined();
             expect(writeResult.dataType).toBe(DataType.Value);
             // TODO(rpaquay): Shoud this be `data` instead?
-            expect(writeResult.data).toBe(null);
+            expect(writeResult.data).toBe('This is another text file');
           }
         );
       }

--- a/lib/axiom/fs/write_result.js
+++ b/lib/axiom/fs/write_result.js
@@ -12,14 +12,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import DataType from 'axiom/fs/data_type';
+
 /** @typedef {SeekWhence$$module$axiom$fs$seek_whence} */
 var SeekWhence;
 
-/** @typedef {DataType$$module$axiom$fs$data_type} */
-var DataType;
-
-/** @constructor */
-export var WriteResult = function(offset, whence, dataType) {
+/**
+ * @constructor
+ * @param {number} offset
+ * @param {SeekWhence} whence
+ * @param {?DataType} dataType
+ * @param {*} data
+ */
+export var WriteResult = function(offset, whence, dataType, data) {
   /** @type {number} */
   this.offset = offset;
 
@@ -27,10 +32,35 @@ export var WriteResult = function(offset, whence, dataType) {
   this.whence = whence;
 
   /** @type {DataType} */
-  this.dataType = dataType;
+  this.dataType = dataType || DataType.UTF8String;
 
+  /** @type {string} */
+  this.mimeType =
+      dataType === DataType.Blob ? '' :
+      dataType === DataType.ArrayBuffer ? 'application/octet-stream' :
+      dataType === DataType.Base64String ? 'application/octet-stream' :
+      dataType === DataType.UTF8String ? 'text/plain' :
+      dataType === DataType.Value ? 'text/json' :
+          '';
+  
   /** @type {*} */
-  this.data = null;
+  this.data =
+      // TODO: Once we turn this into a string the data may already have
+      // been munged.  We need an ArrayBuffer->Base64 string implementation
+      // to make this work for real.
+      dataType === DataType.Base64String ? window.atob(data.toString()) :
+      dataType === DataType.Value ? JSON.stringify(data) :
+          data;
 };
 
 export default WriteResult;
+
+/**
+ * Returns `data` if it's already a Blob, or constructs a new Blow from `data`
+ * and `mimeType`.
+ *
+ * @return {Blob}
+ */
+WriteResult.getBlob = function() {
+  return dataType === DataType.Blob ? data : new Blob([data], {type: mimeType});
+};


### PR DESCRIPTION
@rpaquay 

This is a minimal fix for JSFS. All other FSes can also benefit from this, but I didn't want to muddy this PR with those changes; I'm in the process of implementing them, though, and almost done with that. Will upload tomorrow.