### PR TITLE
Chrome Agent: remove "experimental" permission

### DIFF
--- a/chrome_agent/manifest.json
+++ b/chrome_agent/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 2,
   "name": "Chrome Agent",
   "minimum_chrome_version": "41.0.0.0",
-  "version": "1.0.2",
+  "version": "1.0.3",
 
   "icons": {
     "32": "assets/icon_32.png",
@@ -66,7 +66,6 @@
     "cookies",
     "copresence",
     "debugger",
-    "experimental",
     "history",
     "management",
     "pageCapture",


### PR DESCRIPTION
TBR: @umop 

Extensions with "experimental" can't be made public in CWS :(