### PR TITLE
Make service_worker url absolute.

### DIFF
--- a/samples/web_shell/lib/shell/service_worker.js
+++ b/samples/web_shell/lib/shell/service_worker.js
@@ -40,11 +40,11 @@ ServiceWorker.prototype.register = function() {
   if ('serviceWorker' in navigator) {
 
     var curloc = document.location.href.split('/');
-    curloc = curloc.splice(0, curloc.length - 1).join('/');
+    curloc = curloc.slice(0, -1).join('/');
     var scope = curloc + SCOPE_URL;
     var swURL = curloc + '/service_worker.js';
-    return navigator.serviceWorker.register(swURL,
-        {scope: scope}).then(function(reg) {
+    return navigator.serviceWorker.register(swURL, {scope: scope}).then(
+        function(reg) {
       // registration worked
       console.log('Registration succeeded. Scope is ' + reg.scope);
     }).catch(function(error) {

--- a/samples/web_shell/lib/shell/service_worker.js
+++ b/samples/web_shell/lib/shell/service_worker.js
@@ -16,6 +16,8 @@ import FileSystemManager from 'axiom/fs/base/file_system_manager';
 import Path from 'axiom/fs/path';
 import AxiomError from 'axiom/core/error';
 
+const SCOPE_URL = "/";
+
 /**
  * @constructor
  *
@@ -36,8 +38,13 @@ export default ServiceWorker;
  */
 ServiceWorker.prototype.register = function() {
   if ('serviceWorker' in navigator) {
-    return navigator.serviceWorker.register('/service_worker.js',
-        {scope: '/'}).then(function(reg) {
+
+    var curloc = document.location.href.split('/');
+    curloc = curloc.splice(0, curloc.length-1).join('/');
+    var scope = curloc + SCOPE_URL;
+    var swURL = curloc + '/service_worker.js';
+    return navigator.serviceWorker.register(swURL,
+        {scope: scope}).then(function(reg) {
       // registration worked
       console.log('Registration succeeded. Scope is ' + reg.scope);
     }).catch(function(error) {

--- a/samples/web_shell/lib/shell/service_worker.js
+++ b/samples/web_shell/lib/shell/service_worker.js
@@ -40,7 +40,7 @@ ServiceWorker.prototype.register = function() {
   if ('serviceWorker' in navigator) {
 
     var curloc = document.location.href.split('/');
-    curloc = curloc.splice(0, curloc.length-1).join('/');
+    curloc = curloc.splice(0, curloc.length - 1).join('/');
     var scope = curloc + SCOPE_URL;
     var swURL = curloc + '/service_worker.js';
     return navigator.serviceWorker.register(swURL,


### PR DESCRIPTION
This modifies `service_worker.js` to be loaded from an absolute path.

Fixes the issue, where web_shell assumed the service_worker to be present at the root.

@ussuri PTAL

cc @rginda  The maximum scope of service_worker is confined to  the location from where it is run. Thus service_worker must live under `web_shell/` to allow hosting of `web_shell/**/*` urls. If we put it elsewhere e.g `web_shell/js/boot/`, then it can only serve pages under `web_shell/js/boot/**/*`.