### PR TITLE
Fix closure definition of ReadableStream

### DIFF
--- a/lib/axiom/fs/stream/memory_stream_buffer.js
+++ b/lib/axiom/fs/stream/memory_stream_buffer.js
@@ -38,6 +38,9 @@ var WritableStream;
 export var MemoryStreamBuffer = function() {
   StreamBuffer.call(this);
 
+  /** @type {!AxiomEvent} */
+  this.onEnd = new AxiomEvent();
+
   /** @const @type {!ReadableStream} */
   this.readableStream = new ReadableStreamSource(this);
   /** @const @type {!WritableStream} */
@@ -68,6 +71,7 @@ MemoryStreamBuffer.prototype.flush = function() {
   // This will fire an event chain:
   // this.writableStream.onFinish -> this.onFlush -> this.readableStream.onEnd. 
   this.writableStream.end();
+  this.onEnd.fire();
 };
 
 /**

--- a/lib/axiom/fs/stream/readable_stream.js
+++ b/lib/axiom/fs/stream/readable_stream.js
@@ -24,35 +24,38 @@ import AxiomEvent from 'axiom/core/event';
  *
  * @interface
  */
-export var ReadableStream = function() {
-  /**
-   * When the stream is in flowing mode, onData events are fired with values
-   * as soon as data is available.
-   *
-   * @type {!AxiomEvent}
-   */
-  this.onData = new AxiomEvent();
-  /**
-   * When the stream is in paused mode, onReablable events are fired when
-   * data is available to read.
-   *
-   * @type {!AxiomEvent}
-   */
-  this.onReadable = new AxiomEvent();
-  /**
-   * Fires when there is no more data to read.
-   *
-   * @type {!AxiomEvent}
-   */
-  this.onEnd = new AxiomEvent();
-  /**
-   * Emitted when the underlying resource (for example, the backing file
-   * descriptor) has been closed. Not all streams will emit this.
-   *
-   * @type {!AxiomEvent}
-   */
-  this.onClose = new AxiomEvent();
-};
+export var ReadableStream = function() {};
+
+/**
+  * When the stream is in flowing mode, onData events are fired with values
+  * as soon as data is available.
+  *
+  * @type {!AxiomEvent}
+  */
+ReadableStream.prototype.onData;
+
+/**
+  * When the stream is in paused mode, onReablable events are fired when
+  * data is available to read.
+  *
+  * @type {!AxiomEvent}
+  */
+ReadableStream.prototype.onReadable;
+
+/**
+  * Fires when there is no more data to read.
+  *
+  * @type {!AxiomEvent}
+  */
+ReadableStream.prototype.onEnd;
+
+/**
+  * Emitted when the underlying resource (for example, the backing file
+  * descriptor) has been closed. Not all streams will emit this.
+  *
+  * @type {!AxiomEvent}
+  */
+ReadableStream.prototype.onClose;
 
 /**
  * Switch the stream to paused mode, no more onData events are fired.

--- a/lib/axiom/fs/stream/skeleton_readable_stream.js
+++ b/lib/axiom/fs/stream/skeleton_readable_stream.js
@@ -120,6 +120,8 @@ var ReadableStreamImplementation = function(stream) {
   this.onReadable = this.buffer.onReadable;
   /** @type {!AxiomEvent} */
   this.onClose = this.buffer.onClose;
+  /** @type {!AxiomEvent} */
+  this.onEnd = this.buffer.onEnd;
 };
 
 ReadableStreamImplementation.prototype = Object.create(AxiomStream.prototype);

--- a/lib/axiom/fs/stream/stream_buffer.js
+++ b/lib/axiom/fs/stream/stream_buffer.js
@@ -104,7 +104,7 @@ StreamBuffer.prototype.write = function(value, opt_callback) {
 
 /**
  * Can be overridden by subclasses in case flushing is non-trivial.
- * 
+ *
  * @return {void}
  */
 StreamBuffer.prototype.flush = function() {
@@ -116,7 +116,7 @@ StreamBuffer.prototype.flush = function() {
 
 /**
  * Can be overridden by subclasses in case closing is non-trivial.
- * 
+ *
  * @param {*} error
  * @return {void}
  */


### PR DESCRIPTION
I think I finally figure out the right way to define properties in interface so that closure type checks implementations overrides them. There will be more PR like this coming soon, one interface (and corresponding implementations if needed) at a time.

@rginda 
