### PR TITLE
Fix mount args passing

### DIFF
--- a/lib/wash/exe/mount.js
+++ b/lib/wash/exe/mount.js
@@ -30,16 +30,20 @@ var FileSystemManager;
 export var main = function(cx) {
   cx.ready();
 
-  if (cx.getArg('help') || cx.getArg('_')) {
+  if (cx.getArg('help')) {
     cx.stdout.write([
-      'usage: mount [-t|--type <type>] [-n|--name <name>]',
+      'usage: mount [-t|--type <type>] [-n|--name <name>] [values]',
       'List mounted filesystems, or mount a new file system.',
       '',
       'If called with no arguments this command will list the current mounts.',
+      '',
       'If the -t argument is provided, this will defer to a mount.<type>',
       'executable to mount a new file system.',
       '',
-      'If -n is provided, it\'s passed to the mount command.'
+      'If -n is provided, it\'s passed to the mount.<type> command.',
+      '',
+      'If additional [values] are provided, they are passed to the',
+      'mount.<type> command.',
     ].join('\r\n') + '\r\n');
     cx.closeOk();
     return;
@@ -91,6 +95,9 @@ var mountFileSystem_ = function(cx) {
   var name = cx.getArg('name', null);
   if (name)
     arg['name'] = name;
+  var values = cx.getArg('_', null);
+  if (values)
+    arg['_'] = values;
 
   cx.call(fsMountCmd, arg).then(function() {
     cx.closeOk();


### PR DESCRIPTION
This fixes calling `mount.stream` via `mount --type stream`

@umop 
