### PR TITLE
Add support for "wss:" protocol for "socketfs" command.

### DIFF
--- a/bin/wash.js
+++ b/bin/wash.js
@@ -166,7 +166,7 @@ var socketfs = function(cx) {
       '  -f, --filesystem <file-system-name>',
       '      The name of the filesystem to expose on WebSocket connections.',
       '  -s --ssl',
-      '       Enable https.',
+      '       Enable wss.',
       '  -c --cert <path>',
       '      Path to ssl cert file (default: cert.pem).',
       '  -k --key <path>',


### PR DESCRIPTION
Update the `socketfs` command to support the `wss:` protocol. Usage is similar to the node.js `http-server` command:

```
  -s --ssl
       Enable wss.
  -c --cert <path>
      Path to ssl cert file (default: cert.pem).
  -k --key <path>
      Path to ssl key file (default: key.pem).
```

Note that both -k and -c paths are Axiom paths.

Example:
```
socketfs -p 8000 -f jsfs -ssl -c nodefs:/d:/src/axiom/tools/https-server/cert.pem -k nodefs:/d:/src/axiom/tools/https-server/key.pem
```

@rginda 
